### PR TITLE
Stage 1: document manual SSH sessions and tunneling

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,288 @@
+# Plan: agent-first dev workflow for Sol via `solx` CLI
+
+## Context
+
+Today `sol-skill` covers `/scratch` renewal and Slurm/module conventions. It does not address the live developer loop on Sol — starting an interactive job, tunneling a port back to the laptop, and surviving the network in between. The current workaround requires the user to manually:
+
+1. SSH into Sol → start `interactive` or `vscode`
+2. Note the compute node hostname and the server port
+3. Open a second terminal on the laptop and craft an `ssh -L … -J …` chain
+
+Two terminals, manual state copying, easy to misread (e.g., the user just ran `ssh -L` from the compute node by mistake because their prompt looked the same).
+
+This plan introduces **`solx`**, a Python CLI that becomes the primary product of this repo. The agent skill is reframed as ancillary — it teaches an AI assistant how to drive `solx` (and how to fall back to manual SSH if `solx` is not installed). `solx` is fully usable on its own, with or without an agent. The user's mental model — "I want to work on Sol today, from my laptop" — becomes one command.
+
+Vision constraints from the user (verbatim intent):
+
+- Agent-first CLI; follow Python ecosystem standards.
+- Skill stays light; `solx` lives outside `skills/sol-skill/`.
+- `solx` is a prerequisite for the dev-workflow part of the skill, but **optional** — manual SSH fallback documented.
+- Sol-side config supports multiple named profiles (gpu/debug/etc.).
+- Output personalized with `$(whoami)` / `$USER`, not `<asurite>` placeholders.
+- Strong situational awareness in the skill — detect whether `solx` is installed, branch accordingly.
+- **Security**: published skill must not snoop `~/.ssh/config` or `~/.ssh/known_hosts`. First-time setup must be explicit.
+
+---
+
+## Stages
+
+Work ships in three phases. **Stage 1 and Stage 2 run in parallel** — the skill update is independent of `solx` existing, so it lands first or alongside the CLI rather than waiting on it. This file is the master plan; each stage has a dedicated sub-plan with its own success criteria and testing checklist.
+
+### Stage 1 — Skill manual-SSH path (situational-aware)
+
+Ship the skill changes that work *without* `solx` installed. The skill gains a "Sessions and Tunneling" section that branches on `command -v solx`; with `solx` absent, it walks the user (or agent) through the manual `ssh -L … -J …` chain. After Stage 1, the workflow is documented and usable immediately — `solx` is purely additive from here on.
+
+Deliverables: `references/sessions.md` (manual flow, with `$(whoami)` substitution baked in), `SKILL.md` updated with the detection branch, `references/solx.md` as a stub pointing at Stage 3.
+
+→ Sub-plan: [stage-1-skill.md](stage-1-skill.md)
+
+### Stage 2 — `solx` CLI package (parallel track)
+
+Build the `solx/` package independently of the skill. No skill dependency yet — `solx` is usable from the terminal alone for any human user. Verification is local to `solx/` (`uv run pytest`, plus the Sol- and laptop-side smoke checklists in the sub-plan).
+
+Deliverables: full `solx/` tree per the layout below, installable via `uv tool install`, every mutating subcommand supports `--dry-run`.
+
+→ Sub-plan: [stage-2-solx.md](stage-2-solx.md)
+
+### Stage 3 — Skill ↔ `solx` integration
+
+Once Stage 2 is usable end-to-end, fill in `references/solx.md` with the one-command flow and tighten `SKILL.md`'s detection branch to prefer `solx` when present. Stage 1's manual fallback stays as the second branch — it never goes away.
+
+Deliverables: completed `references/solx.md`, root `README.md` reframed to lead with `solx` as the primary product.
+
+→ Sub-plan: [stage-3-integration.md](stage-3-integration.md)
+
+---
+
+## Repo layout (new)
+
+```text
+sol-skill/
+├── README.md                       # MODIFY — document solx alongside sol_renew
+├── docs/                           # working/helper docs (this PLAN.md, design notes); not shipped with the skill
+├── skills/sol-skill/
+│   ├── SKILL.md                    # MODIFY — add "Sessions & Tunneling" section
+│   ├── scripts/sol_renew.py        # unchanged
+│   └── references/
+│       ├── module.md, scratch.md, sharing.md, slurm.md  # unchanged
+│       ├── sessions.md             # NEW — manual SSH fallback (no solx)
+│       └── solx.md                 # NEW — solx-driven workflow
+└── solx/                           # NEW — the CLI package, separate from the skill
+    ├── pyproject.toml
+    ├── README.md
+    ├── src/solx/
+    │   ├── __init__.py
+    │   ├── __main__.py             # `python -m solx`
+    │   ├── cli.py                  # Typer root + dispatch by side
+    │   ├── side.py                 # detect sol vs laptop (hostname)
+    │   ├── config.py               # TOML profile loading
+    │   ├── session.py              # session.json read/write
+    │   ├── ssh.py                  # build ssh -L -J commands; no ~/.ssh/* reads
+    │   ├── sol_cmds.py             # session start/info/stop, config init
+    │   └── laptop_cmds.py          # init, up/down/forward/info
+    └── tests/                      # pytest, mock subprocess
+```
+
+Distribution: **`uv tool install solx`** (from a path or git URL — same repo, since the skill is ancillary to the CLI and they should version together). Standard ecosystem entry-point — no symlink dance, no PATH guesswork. The existing `sol_renew.py` PEP 723 pattern stays appropriate for a one-file utility; `solx` is multi-file with subcommands and a TOML config layer, so a real package is the right shape.
+
+CLI stack: **Typer + Rich**. Add **Textual** only if a specific subcommand grows real TUI needs (e.g., a session picker with live job status) — defer until then; default to simple Typer prompts.
+
+Framing: the README and repo presentation lead with `solx`. The agent skill becomes a short companion piece that says "use `solx` when present; here's the manual SSH chain otherwise." `solx` works standalone for any human user, with or without an agent.
+
+---
+
+## `solx` design
+
+### Side detection (`solx where`)
+
+Reuse the SKILL.md hostname pattern: `hostname -a` matching `*.sol.rc.asu.edu` → Sol mode; otherwise laptop mode. Subcommands relevant to the wrong side print a clear redirect (no-op, exit 2) instead of failing obscurely.
+
+### Config (multi-profile, user-editable)
+
+**Sol side**: `~/.config/solx/profiles.toml`
+
+```toml
+[shared]
+# Common sbatch/srun options applied to every profile below.
+# Scalars (partition, qos, time) are overridden by per-profile values;
+# lists (forward, srun_args) are appended — shared first, then profile.
+# This is the place to put options you'd otherwise repeat in every profile.
+qos = "public"
+srun_args = [
+  "--mail-type=TIME_LIMIT_90,END,FAIL",   # email at 90% time used, on completion, on failure
+  "--mail-user=swan16@asu.edu",
+]
+
+[default]
+kind = "vscode"        # vscode | bare | sbatch-script
+partition = "lightwork"
+time = "1-0"
+forward = [8888]
+
+[gpu]
+kind = "bare"
+partition = "general"
+gres = "gpu:a100:1"
+time = "0-4"
+forward = [8888, 6006]  # jupyter + tensorboard
+srun_args = ["--mem=64G", "--cpus-per-task=8"]
+
+[debug]
+kind = "bare"
+partition = "htc"
+time = "0-1"
+forward = [8000, 8888]
+```
+
+`solx config init` drops a starter file with these three profiles commented as examples. User edits freely.
+
+**Laptop side**: `~/.config/solx/laptop.toml`
+
+```toml
+host = "sol.asu.edu"     # what to ssh to. User picks during `solx init`.
+user = "swan16"          # filled from `whoami` if not overridden during init
+default_profile = "default"
+
+[shared]
+# Applied to every `solx up` / `down` / `forward` / `info` invocation.
+ssh_args = ["-o", "ServerAliveInterval=30", "-o", "ServerAliveCountMax=3"]
+```
+
+No assumption about ssh aliases, no reading of `~/.ssh/*`. If the user wants to use a custom alias (`Host mysol` in their ssh config), they put `host = "mysol"` here.
+
+### Argument passthrough
+
+Profile fields `srun_args` and `ssh_args` are arrays passed verbatim to `srun` / `ssh`. `solx` does not validate them — typos surface as native srun/ssh errors, which is the right behavior for a thin wrapper.
+
+The `[shared]` table in either config is the place to put **common sbatch/srun options** (or ssh options) that you'd otherwise repeat in every profile. The canonical example is mail notifications — most users want the same notification policy across `default`, `gpu`, and `debug`, so `--mail-type=TIME_LIMIT_90,END,FAIL` and `--mail-user=...` belong in `[shared]`, not in each profile. Same idea on the laptop side for `ssh -o ServerAliveInterval=...`.
+
+CLI escape hatch: anything after `--` on a `solx up` or `solx session start` invocation is appended to the underlying srun command, overriding profile `srun_args` for that one run (`[shared]` `srun_args` still apply unless explicitly displaced by the same flag):
+
+```shell
+solx up gpu -- --mem=128G --time=8:00:00
+```
+
+### Subcommands
+
+#### Universal
+
+- `solx where` — print side + relevant context (compute node, or laptop hostname)
+- `solx config show` — print resolved config
+- `solx --version`, `solx --help`
+
+#### Sol side (run after `ssh sol`)
+
+- `solx session start [PROFILE]` — runs `srun`/`salloc` per profile, writes session.json with `{node, job_id, profile, ports, started_at, kind}`. For `kind=vscode`, wraps the existing `/usr/local/bin/vscode` so its tunnel + a session record both exist.
+- `solx session info [--json]` — read session.json
+- `solx session stop` — `scancel $job_id` + remove session.json
+- `solx config init [--force]`
+
+#### Laptop side
+
+- `solx init` — first-time interactive setup (see Security)
+- `solx up [PROFILE]` — composite: SSH to Sol, runs `solx session start PROFILE` remotely, polls `~/.local/share/solx/session.json` until populated, then opens `ssh -L … -J … <user>@<host> <user>@<node>` for each forwarded port. Drops user into either a remote shell or just leaves tunnels open in foreground (user picks via `--shell` / `--background`).
+- `solx down` — SSHes in, runs `solx session stop`
+- `solx forward PORT [PORT…]` — adds extra tunnels to the running session (uses `ssh -O forward` against the existing ControlMaster socket)
+- `solx info` — `ssh <host> solx session info --json` then pretty-print
+
+### State sharing (no extra protocol)
+
+Sol's `$HOME` is shared between login and compute nodes. The compute node writes `~/.local/share/solx/session.json`; the login node sees it; the laptop reads it via `ssh <host> cat ~/.local/share/solx/session.json`. No daemon, no socket, no extra surface.
+
+### `--dry-run` everywhere
+
+`solx up --dry-run` prints the SSH commands it would run without executing — addresses the "agent ran something I didn't expect" concern, and gives the user a copy-paste fallback identical to the manual route.
+
+---
+
+## Security model
+
+**Never read `~/.ssh/config`, `~/.ssh/known_hosts`, or any key material.** The CLI builds ssh commands from `solx config` only; the user's ssh client handles auth, host-key verification, and ControlMaster sockets natively.
+
+**First-time setup (`solx init` on the laptop)**:
+
+1. Prompts for SSH host (default `sol.asu.edu`).
+2. Prompts for username (default `$(whoami)` — works for users whose laptop and Sol usernames match).
+3. Runs `ssh -o BatchMode=yes -o ConnectTimeout=5 <user>@<host> hostname` to test reachability. Reports clearly if it fails (likely: "no key set up; you'll be prompted for password + Duo on first real connection — that's expected").
+4. **Suggests** (does not write) a `~/.ssh/config` snippet for ControlMaster speedup. User copies it in if they want.
+5. Writes `~/.config/solx/laptop.toml` with mode 0600.
+
+**No secrets in state**: `session.json` contains node, job_id, profile name, port numbers, timestamp. Nothing requiring protection beyond the standard `$HOME` permissions Sol already enforces.
+
+**Auth flow**: Duo + password (or key) handled by the user's `ssh` invocations transparently. `solx up` may prompt 2–3 times during a single command (one for the control connection, possibly more if ControlMaster isn't set up). Document this; recommend ControlMaster.
+
+**Agent safety**: every command that mutates remote state (`up`, `down`, `forward`) supports `--dry-run` and prints the underlying SSH command. The skill instructs the agent to dry-run first when the user hasn't explicitly approved the action.
+
+---
+
+## Skill updates (situational awareness)
+
+`skills/sol-skill/SKILL.md` gains a new section, **Sessions & Tunneling**, that branches on `solx` availability:
+
+```markdown
+## Sessions and Tunneling
+
+To work on Sol from a laptop, you need (a) a running Slurm job and
+(b) SSH tunnels back to the laptop for any localhost server (Jupyter,
+dev server, OAuth callback).
+
+**Detect the tooling first.** Run `command -v solx` on the side you're
+operating from.
+
+- If `solx` is available → see [references/solx.md](references/solx.md)
+  (one-command flow).
+- If not → see [references/sessions.md](references/sessions.md)
+  (manual `ssh -L … -J …`).
+
+**Always personalize examples.** Substitute `$(whoami)` for the
+username — never emit `<asurite>` or other placeholders to the user.
+```
+
+`references/solx.md` — full `solx` workflow doc (config profiles, examples, troubleshooting).
+`references/sessions.md` — pure-SSH manual flow with `whoami` substitution baked in. Pulls forward the working examples from this conversation (chained tunnel, `-J` ProxyJump, OAuth callback, port-already-in-use diagnosis).
+
+---
+
+## Files to create / modify
+
+| Path | Action | Notes |
+| --- | --- | --- |
+| `solx/pyproject.toml` | NEW | Typer + Rich; entry point `solx = "solx.cli:app"`; uses stdlib `tomllib` (Python 3.11+) |
+| `solx/src/solx/cli.py` | NEW | Typer root, dispatches by `side.detect()` |
+| `solx/src/solx/side.py` | NEW | `detect()` reads `hostname`, returns `"sol"` or `"laptop"` |
+| `solx/src/solx/config.py` | NEW | Load/save TOML; profile resolution |
+| `solx/src/solx/session.py` | NEW | `~/.local/share/solx/session.json` r/w |
+| `solx/src/solx/ssh.py` | NEW | Build `ssh -L -J …` commands; never reads `~/.ssh/*` |
+| `solx/src/solx/sol_cmds.py` | NEW | `session start/info/stop`, wraps `/usr/local/bin/vscode` for `kind=vscode` |
+| `solx/src/solx/laptop_cmds.py` | NEW | `init`, `up`, `down`, `forward`, `info` |
+| `solx/tests/` | NEW | pytest with subprocess mocked; covers config parse, profile resolution, ssh-command construction, side detection |
+| `solx/README.md` | NEW | Install, first-run, security notes, examples |
+| `skills/sol-skill/SKILL.md` | MODIFY | Add "Sessions and Tunneling" section with conditional branch |
+| `skills/sol-skill/references/solx.md` | NEW | solx-driven workflow doc |
+| `skills/sol-skill/references/sessions.md` | NEW | Manual SSH fallback doc (consolidates this conversation's working commands) |
+| `README.md` (root) | MODIFY | Reframe to lead with `solx` as the primary product; demote sol-skill agent skill to a "companion" section; updated layout tree |
+
+Reuse from existing code: the `rich` patterns and CLI ergonomics from `skills/sol-skill/scripts/sol_renew.py:1-100` (PEP 723 shebang, argparse layout, exit-code conventions). Mirror those choices in `solx` even though it's a real package — same exit codes (0 ok / 1 failure / 2 conditional), same "preview first" `--dry-run` ethos.
+
+---
+
+## Testing plan
+
+Detailed checklists live with each sub-plan, alongside that stage's success criteria. High-level shape:
+
+| Stage | Side(s) | Where the checklist lives |
+| --- | --- | --- |
+| 1 | Skill (no `solx` required) | [stage-1-skill.md](stage-1-skill.md#testing-checklist) |
+| 2 | Sol + laptop (`solx` standalone) | [stage-2-solx.md](stage-2-solx.md#testing-checklist) |
+| 3 | Skill + `solx` integrated | [stage-3-integration.md](stage-3-integration.md#testing-checklist) |
+
+A change in any sub-plan that affects shared design (config schema, side detection, security model) should be reflected back here so this master plan doesn't drift.
+
+---
+
+## Decisions confirmed
+
+- **CLI framework**: Typer + Rich. Textual reserved for any subcommand that genuinely needs TUI; not adopted up-front.
+- **`solx up` default**: drops user into a remote shell on the compute node after tunnels are open (matches `vscode`/`interactive` mental model). Add `--no-shell` for tunnels-only and `--background` for ControlMaster-detached operation when explicitly requested.
+- **Repo**: same repo, framed as a CLI-primary project with the skill as an ancillary. Install via `uv tool install git+https://github.com/Shu-Wan/sol-skills.git#subdirectory=solx`. Repo rename is out of scope for this plan.
+- **VSCode tunnel integration**: `solx session start` with `kind=vscode` wraps `/usr/local/bin/vscode` rather than reimplementing it. Preserves existing muscle memory and any future ASU changes to the wrapper.

--- a/docs/name.md
+++ b/docs/name.md
@@ -1,0 +1,87 @@
+# CLI Name Candidates
+
+Working name: **`solx`** — tentative, may change before public release.
+
+The CLI described in [PLAN.md](PLAN.md) needs a name that is short, easy to
+type, unambiguous at the shell prompt, and not already taken on PyPI / GitHub /
+Homebrew. Candidates are listed here so the decision is explicit and
+revisitable; nothing below is final.
+
+## Naming principles
+
+### Must-haves
+
+1. **Short.** The name *is* the command — typed many times a day. Target ≤ 6
+   letters; 4 is the sweet spot.
+2. **Unique.** No collision with popular CLIs, PyPI packages, Homebrew
+   formulae, or widely-known GitHub tools. Check before committing — a rename
+   late in Phase 2 is painful.
+
+### Plus factors
+
+- **ASU-tied.** Mascot (Sparky), logo (pitchfork), slogan ("Fork 'em up"),
+  colors (maroon/gold).
+- **Arizona-tied.** Geographic or cultural references (Sonoran, Tempe,
+  saguaro, etc.).
+- **Sol etymology.** Latin/Greek roots tied to the sun — the CLI is a
+  *companion* to Sol, so companion-of-sun words fit well (e.g., *aura*,
+  *lumen*, *solis*, *vesper*).
+- **Subcommand-friendly.** Reads naturally with the subcommands PLAN.md
+  introduces: `<name> up`, `<name> down`, `<name> session start`,
+  `<name> doctor`, `<name> init`.
+- **Pronounceable.** Says cleanly out loud when explaining the tool in a
+  meeting or over chat.
+- **Tab-completion friendly.** Short unique prefix relative to the user's
+  other installed CLIs (so `<prefix><tab>` resolves in one hop).
+- **No clash with existing Sol-cluster tooling.** `sol_renew`, `interactive`,
+  `vscode` already live on Sol; don't pick a name that visually collides with
+  what users already type at the cluster prompt.
+
+## Candidates
+
+### `solx` (current working name)
+
+- **Read as**: "Sol extended / experimental."
+- **For**: short, neutral, signals "not stable yet" while Phase 1 is ongoing.
+- **Against**: no meaning outside this project; doesn't evoke ASU or Sol
+  specifically.
+- **Collisions**: none known in the HPC / developer-tooling space.
+
+### `soldev`
+
+- **Read as**: "Sol dev" to anyone; "Sun Devil" to ASU folks.
+- **For**: dual meaning (Sol developer tool + ASU Sun Devil), short, obvious
+  intent.
+- **Against**: slightly less "experimental" sounding than `solx`; commits to
+  the ASU flavor.
+- **Collisions**: none known.
+
+### `pitchfork` / `pfork`
+
+- **Read as**: ASU logo (the pitchfork).
+- **For**: strong ASU branding, memorable.
+- **Against**: `pitchfork` is long to type; `pfork` reads like a process-fork
+  utility and could confuse. `pitchfork` also collides with the Python
+  `pitchfork` config library.
+- **Collisions**: `pitchfork` exists on PyPI.
+
+### `sparky`
+
+- **Read as**: ASU mascot.
+- **For**: instantly recognizable to ASU users, friendly.
+- **Against**: collides with existing tools (`sparkyfish`, Apache Spark
+  tooling, etc.); ambiguous at the prompt.
+- **Collisions**: multiple on PyPI / GitHub.
+
+### `forkup`
+
+- **Read as**: "Fork 'em up" chant.
+- **For**: fun, ASU-insider.
+- **Against**: reads as git-fork tooling to outsiders; niche appeal.
+- **Collisions**: none known.
+
+## Current stance
+
+Stay on `solx` through Phases 0–1. Revisit before Phase 2 (friendly beta),
+once failure modes are understood and the tool's shape is stable enough that a
+rename wouldn't thrash users.

--- a/docs/stage-1-skill.md
+++ b/docs/stage-1-skill.md
@@ -1,0 +1,48 @@
+# Stage 1 — Skill manual-SSH path (situational-aware)
+
+Sub-plan of [PLAN.md](PLAN.md). This stage runs **in parallel** with Stage 2; it has no dependency on `solx` existing.
+
+## Scope
+
+Update the agent skill so an LLM (or a human reading the docs) can drive the laptop ↔ Sol dev loop using only manual `ssh -L … -J …` chains — no `solx` required. After this stage, the workflow is documented and usable from day one; `solx` becomes purely additive in Stage 3.
+
+Out of scope: any code in `solx/`, any change to `README.md` framing (that's Stage 3).
+
+## Deliverables
+
+| Path | Action | Notes |
+| --- | --- | --- |
+| `skills/sol-skill/references/sessions.md` | NEW | Manual SSH flow: chained `-L`/`-J`, ProxyJump, OAuth callback (`-R`), port-already-in-use diagnosis. All examples use `$(whoami)` substitution. |
+| `skills/sol-skill/references/solx.md` | NEW (stub) | One paragraph pointing at Stage 3. Exists so links from `SKILL.md` don't 404 when `solx` is detected before Stage 3 ships. |
+| `skills/sol-skill/SKILL.md` | MODIFY | Add "Sessions and Tunneling" section with the `command -v solx` detection branch. |
+
+## Implementation notes
+
+- **Detection check**: `command -v solx` (not `which`, not a feature-test). Fast, side-agnostic, exits non-zero when absent.
+- **Username substitution**: instruct the agent to run `whoami` once at the start of the session and substitute throughout — not per-command. Avoids prompt fatigue and keeps copy-paste idiomatic.
+- **`sessions.md` style**: copy-paste-ready commands, not prose. The agent shouldn't have to construct anything from English.
+- **Working examples to consolidate** (pulled forward from past conversations):
+  - Chained tunnel via login node: `ssh -L 8888:localhost:8888 -J swan16@sol.asu.edu swan16@<compute-node>`.
+  - OAuth callback via reverse tunnel (`-R`) for laptop-side OAuth flows.
+  - ControlMaster check/exit (`ssh -O check`, `ssh -O exit`).
+  - "Port already in use" diagnosis (`lsof -i :8888`, `ss -tlnp`).
+- **No reading of `~/.ssh/*`**: even the docs should not instruct the agent to peek at the user's ssh config. If the user has a custom `Host` alias, they can use it directly in the manual commands.
+
+## Success criteria
+
+1. With `solx` not on PATH, the agent answers "start a jupyter session on Sol from my laptop" by running `command -v solx`, finding nothing, and walking through `sessions.md`'s manual chain — without prompting the user for a username (substituted from `whoami`).
+2. A human user can follow `sessions.md` from a clean shell and reach a Jupyter on a compute node without consulting other docs.
+3. `references/solx.md` exists as a stub; clicking through from `SKILL.md` doesn't 404.
+4. `grep -RE '<asurite>|<username>|<user>@' skills/sol-skill/references/` returns nothing — no placeholder leakage.
+5. The `SKILL.md` "Sessions and Tunneling" section is < 30 lines and just routes to one of the two reference docs based on `command -v solx`.
+
+## Testing checklist
+
+1. **Detection branch with `solx` absent**: ensure `solx` is not on PATH; ask the agent "start a jupyter session on Sol from my laptop". Expect:
+   - Agent runs `command -v solx`, sees nothing.
+   - Agent walks through `references/sessions.md`'s manual flow.
+   - All examples use `swan16` (substituted from `whoami`), no placeholders surface to the user.
+2. **Manual flow works end-to-end by hand**: follow `references/sessions.md` from a clean shell. Confirm the chained `ssh -L … -J …` reaches a jupyter on a compute node.
+3. **Stub exists**: `cat skills/sol-skill/references/solx.md` returns a non-empty placeholder pointing at Stage 3.
+4. **No placeholder leakage**: `grep -RE '<asurite>|<username>|<user>@' skills/sol-skill/references/` is empty.
+5. **Detection branch with `solx` present** (re-run after Stage 2 ships): install `solx`, rerun the same prompt. Agent should pivot to `references/solx.md`. Manual fallback remains documented and reachable from `SKILL.md`.

--- a/skills/sol-skill/SKILL.md
+++ b/skills/sol-skill/SKILL.md
@@ -132,6 +132,27 @@ See [references/slurm.md](references/slurm.md) for submission
 commands, example scripts (serial, MPI, job arrays),
 troubleshooting, and exit codes.
 
+## Sessions and Tunneling
+
+To work on Sol from a laptop you need (a) a running Slurm allocation
+and (b) SSH tunnels back to the laptop for any localhost server
+(Jupyter, dev server, OAuth callback).
+
+**Detect the tooling first.** Run `command -v solx` on the side
+you're operating from.
+
+- If `solx` is installed →
+  [references/solx.md](references/solx.md) (one-command flow).
+- If not →
+  [references/sessions.md](references/sessions.md) (manual
+  `ssh -L … -J …` chain).
+
+**Personalize examples.** Run `whoami` once at the start of the
+session and substitute the result into every command before
+showing it. Never emit angle-bracket username placeholders to the
+user. Do not read `~/.ssh/config` or `~/.ssh/known_hosts` — if the
+user has a custom `Host` alias they will tell you.
+
 ## Transferring Data
 
 Use `rsync` for efficient transfers between local and Sol:

--- a/skills/sol-skill/references/sessions.md
+++ b/skills/sol-skill/references/sessions.md
@@ -1,0 +1,215 @@
+# Sessions and tunneling — manual SSH
+
+Use this reference when `command -v solx` finds nothing. It walks the
+laptop ↔ Sol dev loop entirely through the user's existing `ssh`
+client — no extra tooling, no reads of `~/.ssh/*`.
+
+> **Substitute the username once.** At the start of the session, run
+> `whoami` and reuse the result throughout. The examples below set
+> `ME=$(whoami)` once and reference `$ME` afterward. Do not emit
+> angle-bracket username placeholders to the user — substitute first.
+
+## The shape of the problem
+
+To work on Sol from a laptop you need two things:
+
+1. A running Slurm allocation on a **compute node**.
+2. SSH tunnels from the laptop to that compute node so localhost
+   servers (Jupyter, dev server, OAuth callback) reach you.
+
+The login node (`sol.asu.edu`) is reachable from the internet; compute
+nodes are not. Every laptop ↔ compute-node connection therefore has to
+chain through the login node with `-J` (ProxyJump).
+
+```text
+   laptop  ── ssh ──▶  sol.asu.edu (login)  ── ssh ──▶  cXXX (compute)
+                       │  ProxyJump (-J)  │
+   localhost:8888  ◀────────  -L 8888:localhost:8888  ────────┐
+                                                              ▼
+                                                       jupyter on cXXX
+```
+
+## 0. One-time per shell
+
+```shell
+ME=$(whoami)
+SOL=sol.asu.edu          # change if you use a custom Host alias
+```
+
+If you maintain a `Host sol` alias in your own `~/.ssh/config`, set
+`SOL=sol` instead. This doc never reads or modifies your ssh config.
+
+## 1. Start an interactive session on a compute node
+
+From the laptop, SSH to the login node:
+
+```shell
+ssh $ME@$SOL
+```
+
+On the login node, request an allocation. Pick the wrapper that
+matches what you need:
+
+```shell
+# General-purpose interactive shell
+interactive -p general -t 0-04:00 -c 8 --mem=32G
+
+# GPU
+interactive -p general -t 0-04:00 -c 8 --mem=64G -G a100:1
+
+# Lightweight debug
+interactive -p htc -t 0-01:00 -c 4 --mem=16G
+```
+
+When the allocation lands, the prompt changes and you are now on a
+compute node. **Capture the node hostname** — you will need it from
+the laptop:
+
+```shell
+hostname -s     # e.g. cg001
+```
+
+Leave this shell open. Closing it releases the allocation.
+
+## 2. Start the localhost server on the compute node
+
+In the same compute-node shell, start whatever you need to reach.
+Examples:
+
+```shell
+# Jupyter (no browser, no token-rewrite, bound to loopback)
+jupyter lab --no-browser --ip=127.0.0.1 --port=8888
+
+# Plain Python dev server
+python -m http.server 8000 --bind 127.0.0.1
+```
+
+Bind to `127.0.0.1`, never `0.0.0.0` — the tunnel does not need a
+network-facing socket and binding publicly invites trouble on a shared
+node.
+
+## 3. Open the tunnel from the laptop
+
+In a **second laptop terminal** (the first one is your interactive
+shell on the login/compute node), build the chained tunnel.
+
+Replace `cg001` with whatever `hostname -s` reported in step 1.
+
+```shell
+NODE=cg001        # from step 1
+ssh -N -L 8888:localhost:8888 -J $ME@$SOL $ME@$NODE
+```
+
+What each flag does:
+
+| Flag | Purpose |
+| --- | --- |
+| `-N` | Don't run a remote command — tunnel only. |
+| `-L 8888:localhost:8888` | Laptop port 8888 → compute-node port 8888. |
+| `-J $ME@$SOL` | ProxyJump through the login node. |
+
+Now `http://localhost:8888` on the laptop reaches the Jupyter on the
+compute node. Leave this terminal running; Ctrl-C closes the tunnel.
+
+### Forwarding multiple ports
+
+Stack `-L` flags. One common pair: Jupyter (8888) + TensorBoard
+(6006).
+
+```shell
+ssh -N \
+    -L 8888:localhost:8888 \
+    -L 6006:localhost:6006 \
+    -J $ME@$SOL $ME@$NODE
+```
+
+## 4. OAuth callbacks: laptop ▶ compute node (`-R`)
+
+Some flows (e.g. `gh auth login`, cloud SDK browser logins) start a
+web server on the **laptop** and ask the remote process to open a
+URL pointing at it. The remote process can't reach the laptop without
+a reverse tunnel.
+
+```shell
+# Laptop: forward laptop:53682 → compute-node:53682
+ssh -N -R 53682:localhost:53682 -J $ME@$SOL $ME@$NODE
+```
+
+Now anything on the compute node hitting `http://localhost:53682`
+reaches the OAuth helper running on your laptop. Pick whichever port
+the tool prints; some hard-code it (`gcloud` uses 8085, `gh` uses an
+ephemeral port — read the prompt).
+
+## 5. Diagnostics
+
+### "Address already in use"
+
+A previous session on either side may have left a process or a stale
+`-L`/`-R` binding.
+
+On the laptop:
+
+```shell
+lsof -iTCP:8888 -sTCP:LISTEN     # macOS / BSD-style lsof
+ss   -tlnp 'sport = :8888'       # Linux
+```
+
+On the compute node, same commands. Kill the offender or pick a
+different local port (`-L 8889:localhost:8888`).
+
+### Is the ControlMaster still up?
+
+If you have `ControlMaster auto` in your own ssh config (this doc does
+not write it for you), check and tear it down explicitly:
+
+```shell
+ssh -O check $ME@$SOL          # "Master running" or "No ControlMaster"
+ssh -O exit  $ME@$SOL          # close the master cleanly
+```
+
+Closing the master forces the next `-J` chain to re-auth (Duo prompt).
+Useful when a tunnel hangs and you want a clean slate.
+
+### "Did I run -L on the wrong side?"
+
+A `-L` issued from the **compute node** binds the compute node's
+loopback, not the laptop's. If `http://localhost:8888` on the laptop
+still 404s, check the prompt of the shell you ran `-L` in. The chained
+form in step 3 must be issued **from the laptop**.
+
+Quick sanity check:
+
+```shell
+hostname -a
+```
+
+If it ends in `.sol.rc.asu.edu` you are on Sol — abort and re-run the
+`-L` from a laptop terminal.
+
+### Tunnel established but page won't load
+
+In order, check:
+
+1. Server actually listening on `127.0.0.1` on the compute node:
+   `ss -tlnp 'sport = :8888'` from the compute-node shell.
+2. Tunnel still up on the laptop: `ss -tlnp 'sport = :8888'` (Linux)
+   or `lsof -iTCP:8888 -sTCP:LISTEN` (macOS).
+3. Browser: try `curl -v http://localhost:8888` — rules out browser
+   caching/extensions.
+
+## 6. Tear down
+
+- Stop the localhost server on the compute node (Ctrl-C in step 2).
+- Close the tunnel terminal on the laptop (Ctrl-C in step 3).
+- Release the allocation: `exit` from the interactive shell, or run
+  `scancel <jobid>` from the login node (`squeue -u $ME` lists your
+  jobs).
+
+## See also
+
+- `command -v solx` returns a path → use
+  [solx.md](solx.md) instead. It collapses steps 1–3 into a single
+  command on the laptop.
+- [slurm.md](slurm.md) — non-interactive job submission via SBATCH.
+- [module.md](module.md) — loading software inside the interactive
+  shell before starting a server.

--- a/skills/sol-skill/references/solx.md
+++ b/skills/sol-skill/references/solx.md
@@ -1,0 +1,14 @@
+# `solx`-driven sessions and tunneling
+
+> **Stub.** The `solx` CLI is being built in a parallel track. Until
+> it ships, this page is intentionally empty so links from
+> [SKILL.md](../SKILL.md) do not 404.
+
+If `command -v solx` returned a path, the user has installed `solx`
+ahead of this doc landing. Until this page is filled in, fall back to
+the manual SSH flow in [sessions.md](sessions.md) — it produces the
+same end state and stays supported as the "no `solx`" branch in
+perpetuity.
+
+The fully-written workflow (one-command `solx up <profile>`, profile
+config, `--dry-run`) lands in Stage 3 of the rollout plan.


### PR DESCRIPTION
## Summary

Stage 1 of the agent-first dev-workflow rollout (see `docs/PLAN.md` →
`docs/stage-1-skill.md`). Ships the documentation half so the laptop ↔ Sol
loop is usable on day one — no `solx` required.

- **`SKILL.md`** — new "Sessions and Tunneling" section (21 lines)
  that branches on `command -v solx` and routes to one of two
  reference docs. Reminds the agent to `whoami`-substitute usernames
  and to leave `~/.ssh/*` alone.
- **`references/sessions.md`** — full manual flow: `interactive`
  allocation, server bound to `127.0.0.1`, chained `-L … -J …` from
  the laptop, multi-port stacking, OAuth `-R` reverse tunnel,
  ControlMaster check/exit, "wrong side" detection, and
  port-already-in-use diagnosis. All commands set `ME=$(whoami)` once
  and reference `$ME` afterward — no placeholders survive to the
  user.
- **`references/solx.md`** — one-paragraph stub so the
  `solx`-installed branch in `SKILL.md` doesn't 404 before Stage 3
  fills it in. Falls back to `sessions.md` until then.

Stage 2 (`solx/` package) and Stage 3 (skill ↔ CLI integration) are
separate PRs.

## Self-review against Stage 1 success criteria

- [x] `SKILL.md` "Sessions and Tunneling" section is 21 lines (< 30
      required) and only routes — no embedded commands.
- [x] `grep -RE '<asurite>|<username>|<user>@' skills/sol-skill/references/`
      returns nothing.
- [x] `references/solx.md` is a non-empty stub linking back to
      `sessions.md` as the operational fallback.
- [x] `references/sessions.md` is self-contained — covers allocation,
      server, tunnel, OAuth, ControlMaster, diagnosis, teardown
      without requiring any other doc.
- [x] No reads of `~/.ssh/*` documented or instructed anywhere.

## Test plan

- [ ] With `solx` not on PATH, ask the agent "start a jupyter session
      on Sol from my laptop"; confirm it runs `command -v solx`,
      finds nothing, and walks `references/sessions.md` substituting
      `swan16` from `whoami` (no placeholder leakage).
- [ ] Follow `references/sessions.md` from a clean laptop shell and
      reach a Jupyter on a Sol compute node end-to-end.
- [ ] After Stage 2 ships, install `solx` and rerun the same prompt
      — agent should pivot to `references/solx.md` while the manual
      branch stays reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)