### PR TITLE
Replace -p general with -p public; bump to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,25 @@ tag for that release.
 
 ## [Unreleased]
 
-(Changes since v0.2.0 land here. Move them under a new heading on release.)
+(Changes since v0.2.1 land here. Move them under a new heading on release.)
+
+## [0.2.1] — 2026-04-28
+
+Partition rename: ASU Research Computing retired the `general`
+partition in favor of `public`. All SBATCH examples,
+`interactive` wrapper variants, and partition-choice guidance now
+use `-p public` for non-`htc` workloads. Closes #12.
+
+### Changed
+
+- `skills/sol-skill/SKILL.md`, `references/slurm.md`,
+  `references/sessions.md`: replace `-p general` with `-p public`
+  in serial / MPI / job-array templates and interactive-shell
+  examples; update the "save the larger partition for real
+  workloads" guidance to name `public` instead of `general`.
+- `evals/evals.example.json`: GPU PyTorch eval expects `-p public`.
+- `docs/PLAN.md`: planned `solx` `[gpu]` profile uses
+  `partition = "public"`.
 
 ## [0.2.0] — 2026-04-23
 
@@ -114,6 +132,7 @@ agentskills.io-compatible layout (skill content under
 CSV-driven `/scratch` renewal, and shipped the original references
 (`module.md`, `scratch.md`, `sharing.md`, `slurm.md`).
 
-[Unreleased]: https://github.com/Shu-Wan/sol-skills/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/Shu-Wan/sol-skills/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/Shu-Wan/sol-skills/releases/tag/v0.2.1
 [0.2.0]: https://github.com/Shu-Wan/sol-skills/releases/tag/v0.2.0
 [0.1.0]: https://github.com/Shu-Wan/sol-skills/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ sol-skills/
 ## Verification and contributing
 
 - **Version history** — see [`CHANGELOG.md`](CHANGELOG.md). Current
-  release: v0.2.0.
+  release: v0.2.1.
 - **What's tested and how** — see [`docs/coverage.md`](docs/coverage.md)
   for the public methodology and per-area coverage matrix.
 - **Contributing / eval harness internals** — see
@@ -226,7 +226,7 @@ gh skill install Shu-Wan/sol-skills sol-skill --agent github-copilot --scope use
 gh skill preview Shu-Wan/sol-skills sol-skill
 
 # Pin to a specific release
-gh skill install Shu-Wan/sol-skills sol-skill@v0.2.0 --agent claude-code --scope user
+gh skill install Shu-Wan/sol-skills sol-skill@v0.2.1 --agent claude-code --scope user
 
 # Upgrade later
 gh skill update --all

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -134,7 +134,7 @@ forward = [8888]
 
 [gpu]
 kind = "bare"
-partition = "general"
+partition = "public"
 gres = "gpu:a100:1"
 time = "0-4"
 forward = [8888, 6006]  # jupyter + tensorboard

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -5,8 +5,10 @@ automated verification, and what's a known gap. The eval harness
 requires manual orchestration today, so this document is updated by
 hand before each release.
 
-**Version:** v0.2.0 (see [`../CHANGELOG.md`](../CHANGELOG.md))
-**Last verified:** 2026-04-23.
+**Version:** v0.2.1 (see [`../CHANGELOG.md`](../CHANGELOG.md))
+**Last verified:** 2026-04-23 (against v0.2.0 — v0.2.1 is a
+partition-rename release with no behavior changes; tested rows below
+carry over).
 
 ## Status legend
 
@@ -105,7 +107,7 @@ to the skill should mean adding a row here in the same group.
 | Multi-port forwarding (stacked `-L`) | 🟡 documented | |
 | OAuth callback reverse tunnel (`-R`) | 🟡 documented | |
 | Tunnel diagnostics (port-in-use, ControlMaster, wrong-side `-L`) | 🟡 documented | |
-| One-command laptop CLI (`solx`) | ⚪ roadmap | Not in v0.2.0; see [`PLAN.md`](PLAN.md) |
+| One-command laptop CLI (`solx`) | ⚪ roadmap | Not in v0.2.1; see [`PLAN.md`](PLAN.md) |
 | VS Code wrapper (`/usr/local/bin/vscode`) integration | 🔴 gap | Manual smoke only; wrapper itself maintained by ASU |
 
 ### Transferring Data

--- a/evals/evals.example.json
+++ b/evals/evals.example.json
@@ -94,7 +94,7 @@
       "id": 4,
       "name": "slurm-gpu-pytorch-job",
       "prompt": "Write me an sbatch script that trains a PyTorch model on 2 A100s for 4 hours, in a conda env called `vision`.",
-      "expected_output": "SBATCH script with -p general, -G a100:2 (or --gres=gpu:a100:2), -t 0-04:00:00, module load mamba/latest + source activate vision, no sudo.",
+      "expected_output": "SBATCH script with -p public, -G a100:2 (or --gres=gpu:a100:2), -t 0-04:00:00, module load mamba/latest + source activate vision, no sudo.",
       "setup": {
         "mock_hostname": "sc001.sol.rc.asu.edu",
         "include_solx": false

--- a/skills/sol-skill/SKILL.md
+++ b/skills/sol-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sol-skill
-version: 0.2.0
+version: 0.2.1
 description: Tips and conventions for working on ASU's Sol supercomputer. Use this skill when the agent is operating on Sol, submitting SLURM jobs, managing modules, or transferring data on the cluster.
 license: MIT
 ---
@@ -246,17 +246,17 @@ the `interactive` wrapper for interactive shells.
 -c 1 -t 0-4`.** Bare `interactive` (no flags) gets you a 4-hour `htc`
 shell — the right shape for most debug or "just need to check
 something on a compute node" sessions. Override only when the
-workload genuinely needs more (e.g., `interactive -p general -G a100:1`
-for a GPU shell, `interactive -p general -c 16 --mem=64G` for heavy
+workload genuinely needs more (e.g., `interactive -p public -G a100:1`
+for a GPU shell, `interactive -p public -c 16 --mem=64G` for heavy
 CPU work).
 
 **Match the partition to the workload size, not the request size.**
 Sol's `htc` partition is the right home for short, lightweight,
-debug-class work. Use `general` for real workloads that genuinely
+debug-class work. Use `public` for real workloads that genuinely
 need the larger nodes. If the user describes the work as "quick",
 "debug", "lightweight", "just need to check", or specifies under an
 hour with no GPU — that's an `htc` request. Don't default to
-`general` in those cases: defaulting wastes capacity that someone
+`public` in those cases: defaulting wastes capacity that someone
 else is queued for.
 
 **Don't write SBATCH scripts from scratch when a template fits.**
@@ -270,7 +270,7 @@ See [references/slurm.md](references/slurm.md) for submission
 commands, example scripts (serial, MPI, job arrays),
 troubleshooting, and exit codes; and
 [references/sessions.md](references/sessions.md) for the
-`interactive` wrapper variants by workload type (debug, general,
+`interactive` wrapper variants by workload type (debug, public,
 GPU).
 
 ## Asking the Cluster About Yourself and Your Jobs

--- a/skills/sol-skill/references/sessions.md
+++ b/skills/sol-skill/references/sessions.md
@@ -59,8 +59,8 @@ ssh $ME@$SOL
 On the login node, request an allocation. **Match the partition to
 the workload size**, not the request size — Sol's `htc` partition is
 the right home for short, lightweight, debug-class shells (anything
-under ~1 hour, modest CPU/RAM, no GPU). Save `general` for real
-work that genuinely needs the larger nodes. Picking `general` for a
+under ~1 hour, modest CPU/RAM, no GPU). Save `public` for real
+work that genuinely needs the larger nodes. Picking `public` for a
 30-minute debug shell wastes capacity that someone else is queued for.
 
 ```shell
@@ -70,15 +70,15 @@ work that genuinely needs the larger nodes. Picking `general` for a
 interactive -p htc -t 0-01:00 -c 4 --mem=16G
 
 # General-purpose interactive shell — hours of CPU work
-interactive -p general -t 0-04:00 -c 8 --mem=32G
+interactive -p public -t 0-04:00 -c 8 --mem=32G
 
 # GPU
-interactive -p general -t 0-04:00 -c 8 --mem=64G -G a100:1
+interactive -p public -t 0-04:00 -c 8 --mem=64G -G a100:1
 ```
 
 If the user describes the work as "quick", "debug", "lightweight",
 "just need to check", or specifies under an hour with no GPU — that's
-an `htc` request. Don't default to `general` in those cases.
+an `htc` request. Don't default to `public` in those cases.
 
 When the allocation lands, the prompt changes and you are now on a
 compute node. **Capture the node hostname** — you will need it from

--- a/skills/sol-skill/references/slurm.md
+++ b/skills/sol-skill/references/slurm.md
@@ -65,7 +65,7 @@ Additional templates live on the cluster at:
 #SBATCH -N 1            # number of nodes
 #SBATCH -c 8            # number of cores
 #SBATCH -t 0-01:00:00   # time in d-hh:mm:ss
-#SBATCH -p general      # partition
+#SBATCH -p public       # partition
 #SBATCH -q public       # QOS
 #SBATCH -o slurm.%j.out # STDOUT (%j = JobId)
 #SBATCH -e slurm.%j.err # STDERR (%j = JobId)
@@ -93,7 +93,7 @@ to tasks across one or more nodes.
 #SBATCH -n 8            # number of tasks
 #SBATCH -c 1            # cores per task (default 1)
 #SBATCH -t 0-01:00:00
-#SBATCH -p general
+#SBATCH -p public
 #SBATCH -q public
 #SBATCH -o slurm.%j.out
 #SBATCH -e slurm.%j.err
@@ -119,7 +119,7 @@ parameters. A **manifest file** lists the input parameters.
 #SBATCH -c 1
 #SBATCH --array=1-20
 #SBATCH -t 0-01:00:00
-#SBATCH -p general
+#SBATCH -p public
 #SBATCH -q public
 #SBATCH -o slurm.%j.out
 #SBATCH -e slurm.%j.err


### PR DESCRIPTION
## Summary

- ASU Research Computing retired the `general` partition; `public` is the replacement. Update SBATCH templates, `interactive` wrapper examples, and partition-choice guidance in `SKILL.md` and references to use `-p public` for non-`htc` workloads.
- Sync `evals/evals.example.json` GPU PyTorch eval and the planned `solx` `[gpu]` profile in `docs/PLAN.md`.
- Bump skill version to v0.2.1 and add a CHANGELOG entry.

Closes #12.

## Test plan

- [ ] Verify no remaining `-p general` references: `grep -rn "p general" skills/ docs/ evals/`
- [ ] Confirm `sinfo` on Sol shows `public` as an active partition
- [ ] Sanity-check `sol-skill/SKILL.md` version field reads `0.2.1`
- [ ] Re-run the GPU PyTorch eval (id 4) under the eval harness once tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)