### PR TITLE
docs: pivot Stage 2 to Sol-first CLI; defer laptop side and Stage 3

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -113,10 +113,10 @@ genuinely needs TUI.
 | `solx init` | First-run: write a starter `config.toml` |
 | `solx job list` (alias `ls`) | List my Sol jobs |
 | `solx job start [TEMPLATE]` | Start an interactive allocation (`salloc --no-shell`) from a config template |
-| `solx job stop [JOBID]` | Cancel a job |
+| `solx job stop [JOBID] [-y] [-n]` | Cancel a job (prompts unless `-y`; `-n` previews) |
 | `solx job jump [JOBID]` (also `solx jump`) | Drop into a shell on the job's compute node |
 | `solx job time [JOBID]` | Remaining time (Slurm `D-HH:MM:SS`) |
-| `solx keep [--stage S] [--csv-dir D] [-j N] [-n] [-v]` | Renew CSV-flagged scratch files filtered by `[keep]` (port of `sol_renew.py`) |
+| `solx keep [--stage S] [--csv-dir D] [-j N] [-y] [-n] [-v]` | Renew CSV-flagged scratch files filtered by `[keep]` (prompts unless `-y`; `-n` previews; port of `sol_renew.py`) |
 | `solx config show` / `edit` | Inspect / edit the single TOML config |
 | `solx completions <shell>` | Emit shell completions |
 | `solx --version` / `--help` | — |
@@ -129,6 +129,10 @@ Defaults and aliases:
 - `jump` is also reachable at the top level — `solx jump [JOBID]` is
   shorthand for `solx job jump [JOBID]`. (It's the verb you reach for
   most; the shortcut earns its keep.)
+- Destructive commands (`solx job stop`, `solx keep`) prompt for
+  confirmation by default. `-y` / `--yes` skips the prompt for
+  scripts; `-n` / `--dry-run` previews the action without executing
+  it (and without prompting — nothing is about to happen).
 - Anywhere a `[JOBID]` is omitted, `solx` resolves it: `$SLURM_JOB_ID`
   on a compute node, the user's only running job on a login node, or
   a Rich table of all jobs (with exit 2) when ambiguous.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,10 +1,9 @@
-# Roadmap: optional `solx` CLI
+# Roadmap: Sol-first `solx` CLI
 
-Forward-looking design doc for **`solx`**, an optional one-command
-CLI that would collapse the laptop ↔ Sol dev loop (allocate compute
-node + tunnel localhost ports back) into a single invocation. Not
-part of any released version. The skill (shipped) covers the manual
-path; `solx` would be an additive convenience layer.
+Forward-looking design doc for **`solx`**, a Python CLI for working
+on ASU's **Sol** supercomputer. Not part of any released version
+yet. The agent skill (shipped) covers the manual path; `solx` is an
+additive convenience layer for terminal-driven work on Sol.
 
 End-user docs: [`../README.md`](../README.md),
 [`../skills/sol-skill/SKILL.md`](../skills/sol-skill/SKILL.md).
@@ -12,301 +11,185 @@ Contributor / harness docs: [`../DEVELOPMENT.md`](../DEVELOPMENT.md),
 [`coverage.md`](coverage.md). Released history:
 [`../CHANGELOG.md`](../CHANGELOG.md).
 
+## Pivot — what changed and why
+
+Earlier drafts of this plan envisioned a "one magic command from the
+laptop" — `solx up <profile>` would SSH to Sol, allocate, open
+tunnels, and drop the user into a shell, in one shot. That vision
+threads laptop-side ssh-client behavior, ControlMaster, Duo, and
+Slurm queue-wait races, none of which are unit-testable and all of
+which need real laptop ↔ Sol round-trips to validate.
+
+Rather than ship a brittle one-command flow, we are **deferring the
+laptop side entirely** until the design is more mature. `solx` is
+now a **Sol-first CLI**: the user reaches Sol the manual way (per the
+already-shipped `references/sessions.md`), then runs `solx` from
+there. Everything `solx` does — list jobs, start an interactive
+allocation, drop into a shell on the compute node, cancel, query
+remaining time, keep `/scratch` files alive — happens on Sol.
+
+The laptop side is not cancelled, just **deferred for further
+discussion**. It returns when the Sol-side primitives are stable,
+the design has been re-thought from scratch, and the user has
+greenlit it.
+
 ## Stages
 
-| Stage | Outcome |
-|---|---|
-| 1 — Skill manual-SSH path | Shipped in v0.2.0 (see CHANGELOG). |
-| 2 — `solx` CLI package | `solx/` standalone package, `uv tool install`-able, every mutating subcommand supports `--dry-run`. Designed below. |
-| 3 — Skill ↔ `solx` integration | Add `command -v solx` detection branch into SKILL.md; populate `references/solx.md` with the one-command flow. Depends on Stage 2. |
+| Stage | Outcome | Status |
+|---|---|---|
+| 1 — Skill manual-SSH path | Shipped in v0.2.0 (see CHANGELOG). | ✅ shipped |
+| 2 — `solx` CLI (Sol-only) | `solx/` package, installable on Sol via `uv tool install`. Covers daily Sol use: jobs, interactive allocation, scratch renewal, config. See [`stage-2-solx.md`](stage-2-solx.md). | 🟡 in progress |
+| 3 — Skill ↔ `solx` integration | Skill detects `solx` and teaches the CLI flow alongside the manual fallback. **Deferred until Stage 2 is mature and the user gives the greenlight.** See [`stage-3-integration.md`](stage-3-integration.md). | ⚪ deferred |
 
-## Why a `solx` CLI
+## Design principles
 
-The current dev loop on Sol from a laptop, even with the v0.2.0
-skill teaching the right commands:
+These are the load-bearing constraints for `solx`. Every decision
+below derives from them.
 
-1. SSH into Sol → start `interactive` (or `vscode`).
-2. Note the compute node hostname and the server port.
-3. Open a second terminal on the laptop and craft an `ssh -L … -J …`
-   chain.
+1. **Sol-first.** The CLI is meant to be run *on* Sol after a manual
+   SSH. No laptop side, no ssh-chain construction, no `~/.ssh/*`
+   reads. If you want one-command magic from your laptop, that's a
+   separate (deferred) conversation.
+2. **Intuitive and not disruptive.** Verbs read like Sol-native
+   commands. `solx job list`, `solx job start`, `solx keep`. No
+   surprising side effects. Mutating commands support `--dry-run`.
+3. **Common CLI conventions.** Noun-verb command groups (`solx job
+   list/start/stop/shell/time`) for related operations; flags for
+   leaf commands (`solx keep --dry-run`). Shell completions provided
+   for bash, zsh, fish.
+4. **Read config, don't infer.** A single TOML config under
+   `$XDG_CONFIG_HOME/solx/config.toml` declares everything. No
+   environment-variable trickery, no hidden discovery, no scanning
+   `~/.ssh/*`.
+5. **Slurm is the source of truth, not us.** No persistent
+   `session.json` to go stale. The CLI queries `squeue` whenever it
+   needs job state.
+6. **General, not personal.** The starter config ships with
+   placeholders, never with the maintainer's username baked in.
 
-Two terminals, manual state copying, easy to misread (e.g., the user
-runs `ssh -L` from the compute node by mistake because the prompt
-looks the same). Open OnDemand handles the casual notebook case
-without any of this fiddliness; `solx` would handle the
-terminal-driven power-user case by collapsing all three steps into
-`solx up <profile>` from the laptop.
-
-## Vision constraints
-
-Carry-over from earlier planning. Still valid:
-
-- Agent-first CLI; follow Python ecosystem standards.
-- Skill stays light; `solx` lives outside `skills/sol-skill/`.
-- `solx` is a prerequisite for the dev-workflow part of the skill,
-  but **optional** — manual SSH fallback documented and supported in
-  perpetuity.
-- Sol-side config supports multiple named profiles (gpu/debug/etc.).
-- Output personalized with `$(whoami)` / `$USER`, never `<asurite>`
-  placeholders.
-- Strong situational awareness in the skill — once `solx` ships, the
-  skill detects it and branches accordingly.
-- **Security**: published skill must not snoop `~/.ssh/config` or
-  `~/.ssh/known_hosts`. First-time setup must be explicit.
-
-## Repo layout (target after Stages 2 + 3)
+## Repo layout (target)
 
 ```text
 sol-skill/
-├── README.md                       # would gain a solx install + intro section
+├── README.md                       # primary skill README, lightly touched
 ├── docs/
-├── skills/sol-skill/
-│   ├── SKILL.md                    # would gain `command -v solx` detection branch (Stage 3)
+│   ├── PLAN.md                     # this file
+│   ├── stage-2-solx.md             # Sol-only CLI sub-plan
+│   ├── stage-3-integration.md      # deferred sub-plan
+│   ├── solx.md                     # user manual (rewritten in PR #2)
+│   ├── solx-smoke.md               # smoke checklist (rewritten in PR #2)
+│   ├── coverage.md
+│   └── name.md
+├── skills/sol-skill/               # untouched — the skill ships with sol_renew.py
+│   ├── SKILL.md
 │   ├── scripts/sol_renew.py
 │   └── references/
-│       ├── module.md, scratch.md, sharing.md, slurm.md, sessions.md  # already shipped
-│       └── solx.md                 # NEW (Stage 3) — solx-driven workflow
-└── solx/                           # NEW (Stage 2) — the CLI package
+└── solx/                           # CLI package — rewritten in PR #2
     ├── pyproject.toml
     ├── README.md
     ├── src/solx/
     │   ├── __init__.py
-    │   ├── __main__.py             # `python -m solx`
-    │   ├── cli.py                  # Typer root + dispatch by side
-    │   ├── side.py                 # detect sol vs laptop (sacctmgr-based)
-    │   ├── config.py               # TOML profile loading
-    │   ├── session.py              # session.json read/write
-    │   ├── ssh.py                  # build ssh -L -J commands; no ~/.ssh/* reads
-    │   ├── sol_cmds.py             # session start/info/stop, config init
-    │   └── laptop_cmds.py          # init, up/down/forward/info
-    └── tests/                      # pytest, mock subprocess
+    │   ├── __main__.py
+    │   ├── cli.py                  # Typer root
+    │   ├── config.py               # XDG TOML loader
+    │   ├── side.py                 # Sol-vs-not-Sol guard
+    │   ├── slurm.py                # squeue/scancel/sbatch wrappers; jobid resolution
+    │   ├── jobs.py                 # `solx job *`
+    │   ├── keep.py                 # `solx keep`
+    │   └── init.py                 # `solx init`
+    └── tests/
 ```
 
-Distribution: **`uv tool install solx`** (path or git URL — same
-repo, since the skill and CLI version together).
+Distribution: **`uv tool install`** from the same repo (the CLI and
+skill version together long-term, even though Stage 3 is deferred).
 
-CLI stack: **Typer + Rich**. Add **Textual** only if a specific
-subcommand grows real TUI needs (e.g., a session picker with live job
-status); default to simple Typer prompts.
+CLI stack: **Typer + Rich**. Defer Textual until a subcommand
+genuinely needs TUI.
 
-## `solx` design
+## What `solx` does, top level
 
-### Side detection (`solx where`)
+| Command | What it does |
+|---|---|
+| `solx init` | First-run: write a starter `config.toml` |
+| `solx job list` (alias `ls`) | List my Sol jobs |
+| `solx job start [TEMPLATE]` | Start an interactive allocation (`salloc --no-shell`) from a config template |
+| `solx job stop [JOBID]` | Cancel a job |
+| `solx job jump [JOBID]` (also `solx jump`) | Drop into a shell on the job's compute node |
+| `solx job time [JOBID]` | Remaining time (Slurm `D-HH:MM:SS`) |
+| `solx keep [--dry-run]` | Extend `/scratch` file mtimes for paths declared in config |
+| `solx config show` / `edit` | Inspect / edit the single TOML config |
+| `solx completions <shell>` | Emit shell completions |
+| `solx --version` / `--help` | — |
 
-Use the same SLURM-side signals the v0.2.0 skill teaches (see
-`SKILL.md` "Detecting the Environment"):
+Defaults and aliases:
 
-1. `command -v sacctmgr` — empty → not on a Slurm cluster → must be
-   laptop side.
-2. `sacctmgr -n show cluster format=cluster` — `sol` → Sol;
-   anything else → wrong cluster, exit non-zero with a clear
-   message.
-3. `$SLURM_JOB_ID` — set → already inside an allocation (warn:
-   `solx session start` from inside an allocation is almost always a
-   mistake).
+- The `job` subgroup is also reachable as `jobs`, and `list` is also
+  reachable as `ls`. `solx job list`, `solx jobs list`, `solx job ls`,
+  and `solx jobs ls` are all equivalent.
+- `jump` is also reachable at the top level — `solx jump [JOBID]` is
+  shorthand for `solx job jump [JOBID]`. (It's the verb you reach for
+  most; the shortcut earns its keep.)
+- Anywhere a `[JOBID]` is omitted, `solx` resolves it: `$SLURM_JOB_ID`
+  on a compute node, the user's only running job on a login node, or
+  a Rich table of all jobs (with exit 2) when ambiguous.
+- `solx job start` defaults to the `default_template` config key.
+- `solx job time` prints in Slurm's `D-HH:MM:SS` format, matching
+  `squeue -O TimeLeft`.
 
-Subcommands relevant to the wrong side print a clear redirect (no-op,
-exit 2) instead of failing obscurely.
-
-### Config (multi-profile, user-editable)
-
-**Sol side**: `~/.config/solx/profiles.toml`
-
-```toml
-[shared]
-# Common sbatch/srun options applied to every profile below.
-# Scalars (partition, qos, time) are overridden by per-profile values;
-# lists (forward, srun_args) are appended — shared first, then profile.
-qos = "public"
-srun_args = [
-  "--mail-type=TIME_LIMIT_90,END,FAIL",
-  "--mail-user=swan16@asu.edu",
-]
-
-[default]
-# Lightweight default — matches the `interactive` wrapper's defaults
-# (htc partition, public QOS) which the SKILL teaches as the right
-# choice for short, exploratory work.
-kind = "vscode"        # vscode | bare | sbatch-script
-partition = "htc"
-time = "0-4"
-forward = [8888]
-
-[gpu]
-kind = "bare"
-partition = "public"
-gres = "gpu:a100:1"
-time = "0-4"
-forward = [8888, 6006]  # jupyter + tensorboard
-srun_args = ["--mem=64G", "--cpus-per-task=8"]
-
-[debug]
-kind = "bare"
-partition = "htc"
-time = "0-1"
-forward = [8000, 8888]
-```
-
-`solx config init` drops a starter file with these three profiles
-commented as examples. User edits freely.
-
-**Laptop side**: `~/.config/solx/laptop.toml`
-
-```toml
-host = "sol.asu.edu"     # what to ssh to. User picks during `solx init`.
-user = "swan16"          # filled from `whoami` if not overridden during init
-default_profile = "default"
-
-[shared]
-# Applied to every `solx up` / `down` / `forward` / `info` invocation.
-ssh_args = ["-o", "ServerAliveInterval=30", "-o", "ServerAliveCountMax=3"]
-```
-
-No assumption about ssh aliases, no reading of `~/.ssh/*`. If the
-user wants a custom alias (`Host mysol` in their ssh config), they
-put `host = "mysol"` here.
-
-### Argument passthrough
-
-Profile fields `srun_args` and `ssh_args` are arrays passed verbatim
-to `srun` / `ssh`. `solx` does not validate them — typos surface as
-native srun/ssh errors, the right behavior for a thin wrapper.
-
-`[shared]` is for options you'd otherwise repeat in every profile
-(canonical example: mail notifications). CLI escape hatch: anything
-after `--` on `solx up` or `solx session start` is appended to the
-underlying srun command, overriding profile `srun_args` for that one
-run:
-
-```shell
-solx up gpu -- --mem=128G --time=8:00:00
-```
-
-### Subcommands
-
-#### Universal
-
-- `solx where` — print side + relevant context
-- `solx config show` — print resolved config
-- `solx --version`, `solx --help`
-
-#### Sol side (run after `ssh sol`)
-
-- `solx session start [PROFILE]` — runs `srun`/`salloc` per profile,
-  writes `session.json` with `{node, job_id, profile, ports,
-  started_at, kind}`. For `kind=vscode`, wraps the existing
-  `/usr/local/bin/vscode` so its tunnel + a session record both
-  exist.
-- `solx session info [--json]` — read `session.json`
-- `solx session stop` — `scancel $job_id` + remove `session.json`
-- `solx config init [--force]`
-
-#### Laptop side
-
-- `solx init` — first-time interactive setup (see Security below)
-- `solx up [PROFILE]` — composite: SSH to Sol, runs `solx session
-  start PROFILE` remotely, polls `~/.local/share/solx/session.json`
-  until populated, then opens `ssh -L … -J … <user>@<host>
-  <user>@<node>` for each forwarded port. Drops user into either a
-  remote shell or just leaves tunnels open in foreground (user picks
-  via `--shell` / `--background`).
-- `solx down` — SSHes in, runs `solx session stop`
-- `solx forward PORT [PORT…]` — adds extra tunnels to the running
-  session (uses `ssh -O forward` against the existing ControlMaster
-  socket)
-- `solx info` — `ssh <host> solx session info --json` then
-  pretty-print
-
-### State sharing (no extra protocol)
-
-Sol's `$HOME` is shared between login and compute nodes. The compute
-node writes `~/.local/share/solx/session.json`; the login node sees
-it; the laptop reads it via `ssh <host> cat
-~/.local/share/solx/session.json`. No daemon, no socket, no extra
-surface.
-
-### `--dry-run` everywhere
-
-`solx up --dry-run` prints the SSH commands it would run without
-executing — addresses the "agent ran something I didn't expect"
-concern, and gives the user a copy-paste fallback identical to the
-manual route.
+Full surface details, config schema, and the rewrite plan against
+the existing `solx/` source tree live in
+[`stage-2-solx.md`](stage-2-solx.md).
 
 ## Security model
 
-**Never read `~/.ssh/config`, `~/.ssh/known_hosts`, or any key
-material.** The CLI builds ssh commands from `solx config` only; the
-user's ssh client handles auth, host-key verification, and
-ControlMaster sockets natively.
+`solx` is Sol-only by design, so the security surface is small:
 
-**First-time setup (`solx init` on the laptop)**:
+- Never read `~/.ssh/*`. The CLI doesn't invoke `ssh` at all in this
+  release.
+- The single config (`$XDG_CONFIG_HOME/solx/config.toml`) is created
+  with mode 0600.
+- `solx keep` only touches files under directories the user has
+  declared in `[keep]`. Mutates `atime`/`mtime` only — never reads,
+  moves, or deletes content.
+- Mutating commands (`job start`, `job stop`, `keep`) print the
+  underlying Slurm/`touch` invocations they would run with
+  `--dry-run` first.
 
-1. Prompts for SSH host (default `sol.asu.edu`).
-2. Prompts for username (default `$(whoami)` — works for users whose
-   laptop and Sol usernames match).
-3. Runs `ssh -o BatchMode=yes -o ConnectTimeout=5 <user>@<host>
-   hostname` to test reachability. Reports clearly if it fails
-   (likely: "no key set up; you'll be prompted for password + Duo on
-   first real connection — that's expected").
-4. **Suggests** (does not write) a `~/.ssh/config` snippet for
-   ControlMaster speedup. User copies it in if they want.
-5. Writes `~/.config/solx/laptop.toml` with mode 0600.
-
-**No secrets in state**: `session.json` contains node, job_id,
-profile name, port numbers, timestamp. Nothing requiring protection
-beyond the standard `$HOME` permissions Sol already enforces.
-
-**Auth flow**: Duo + password (or key) handled by the user's `ssh`
-invocations transparently. `solx up` may prompt 2–3 times during a
-single command. Document this; recommend ControlMaster.
-
-**Agent safety**: every command that mutates remote state (`up`,
-`down`, `forward`) supports `--dry-run` and prints the underlying
-SSH command. The skill instructs the agent to dry-run first when the
-user hasn't explicitly approved the action.
-
-## Stage 3: when `solx` ships, the skill needs this
-
-Once Stage 2 is usable end-to-end, the SKILL's "Using a Service That
-Runs on Sol, From Your Laptop" section gains a third path: detect
-`solx` on the laptop side, prefer the one-command flow if present,
-fall back to the manual SSH chain if not. Concretely:
-
-- Add a `command -v solx` check to the section opener.
-- Add a new `references/solx.md` walking through `solx init`, `solx
-  up <profile>`, `solx forward`, and `solx down` with worked
-  examples.
-- Update `docs/coverage.md` to add a `solx`-detection-branch row in
-  the Sessions section (would flip the existing ⚪ roadmap row to
-  🟡 documented or 🟢 tested).
-- Bump the skill version (frontmatter `version`) and add a
-  `CHANGELOG.md` entry describing the new branch.
-
-## Files to create / modify (Stages 2 + 3)
-
-| Path | Stage | Action |
-|---|---|---|
-| `solx/pyproject.toml` | 2 | NEW — Typer + Rich; entry point `solx = "solx.cli:app"`; uses stdlib `tomllib` (Python 3.11+) |
-| `solx/src/solx/cli.py` | 2 | NEW — Typer root, dispatches by `side.detect()` |
-| `solx/src/solx/side.py` | 2 | NEW — `detect()` uses `sacctmgr` and `$SLURM_JOB_ID`, returns `"sol-login"` / `"sol-compute"` / `"laptop"` |
-| `solx/src/solx/config.py` | 2 | NEW — Load/save TOML; profile resolution |
-| `solx/src/solx/session.py` | 2 | NEW — `~/.local/share/solx/session.json` r/w |
-| `solx/src/solx/ssh.py` | 2 | NEW — Build `ssh -L -J …` commands; never reads `~/.ssh/*` |
-| `solx/src/solx/sol_cmds.py` | 2 | NEW — `session start/info/stop`, wraps `/usr/local/bin/vscode` for `kind=vscode` |
-| `solx/src/solx/laptop_cmds.py` | 2 | NEW — `init`, `up`, `down`, `forward`, `info` |
-| `solx/tests/` | 2 | NEW — pytest with subprocess mocked; covers config parse, profile resolution, ssh-command construction, side detection |
-| `solx/README.md` | 2 | NEW — install, first-run, security notes, examples |
-| `skills/sol-skill/SKILL.md` | 3 | MODIFY — add `command -v solx` branch to "Using a Service…" section |
-| `skills/sol-skill/references/solx.md` | 3 | NEW — `solx`-driven workflow walkthrough |
-| `README.md` (root) | 3 | MODIFY — mention `solx` install path alongside the skill install |
-| `docs/coverage.md` | 3 | MODIFY — add solx-related rows |
-| `CHANGELOG.md` | 3 | MODIFY — describe the new branch + skill version bump |
-
-Reuse from existing code: the patterns from `skills/sol-skill/scripts/sol_renew.py` (PEP 723 shebang, argparse/Rich layout, exit-code conventions). Mirror those choices in `solx` even though it's a real package — same exit codes (`0` ok / `1` failure / `2` conditional), same "preview first" `--dry-run` ethos.
+When laptop-side work returns (deferred), a fresh security review of
+that surface comes with it. Nothing in this stage commits us to a
+specific laptop-side design.
 
 ## Decisions confirmed
 
-- **CLI framework**: Typer + Rich. Textual reserved for any subcommand that genuinely needs TUI; not adopted up-front.
-- **`solx up` default**: drops user into a remote shell on the compute node after tunnels are open (matches `vscode`/`interactive` mental model). Add `--no-shell` for tunnels-only and `--background` for ControlMaster-detached operation.
-- **Repo**: same repo, framed as a skill-primary project with `solx` as a CLI add-on. Install `solx` via `uv tool install git+https://github.com/Shu-Wan/sol-skills.git#subdirectory=solx`. Repo rename out of scope.
-- **VSCode tunnel integration**: `solx session start` with `kind=vscode` wraps `/usr/local/bin/vscode` rather than reimplementing it. Preserves muscle memory and any future ASU changes to the wrapper.
+- **CLI framework**: Typer + Rich. Defer Textual.
+- **Config**: single TOML under `$XDG_CONFIG_HOME/solx/config.toml`.
+  No multi-file split, no `[shared]` merge — one config, easy to
+  read.
+- **Glob library for `[keep]`**: `pathspec` (mature; handles
+  `include` + `exclude` arrays similar to Ruff's config style).
+- **State tracking**: none. `squeue -u $USER` is the source of truth.
+  No `session.json`, no stale-state class of bugs. Cost: one `squeue`
+  call per command — fine on a login node.
+- **Default jobid resolution**: argument > `$SLURM_JOB_ID` (compute
+  node) > sole running job (login node) > Rich table + exit 2 when
+  ambiguous.
+- **Repo layout**: same repo, CLI under `solx/`, skill under
+  `skills/sol-skill/` — they ship together long-term but Stage 3
+  integration is deferred. The skill currently makes no reference to
+  `solx` and continues to teach `sol_renew.py` for scratch renewal.
+- **`vscode` / `sbatch` wrappers**: out of scope. `solx` is for
+  interactive jobs; for VSCode, run `code tunnel` directly on a
+  compute node. For batch work, `sbatch your-script.sbatch` directly.
+- **Skill subcommands** (`solx skill install/remove/...`): reserved
+  in the eventual surface, **not implemented in Stage 2**. They
+  return with Stage 3.
+
+## What ships when
+
+- **PR #1 (this branch)** — pivot the planning docs (`PLAN.md`,
+  `stage-2-solx.md`, `stage-3-integration.md`). No code change. Locks
+  the contract.
+- **PR #2** — rewrite the `solx/` package against `stage-2-solx.md`,
+  rewrite `docs/solx.md` and `docs/solx-smoke.md`, smoke-test on
+  Sol. Skill files untouched.
+- **PR #3+** — Stage 3 work, only after the user greenlights.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -54,7 +54,7 @@ below derives from them.
    commands. `solx job list`, `solx job start`, `solx keep`. No
    surprising side effects. Mutating commands support `--dry-run`.
 3. **Common CLI conventions.** Noun-verb command groups (`solx job
-   list/start/stop/shell/time`) for related operations; flags for
+   list/start/stop/jump/time`) for related operations; flags for
    leaf commands (`solx keep --dry-run`). Shell completions provided
    for bash, zsh, fish.
 4. **Read config, don't infer.** A single TOML config under
@@ -93,7 +93,7 @@ sol-skill/
     │   ├── cli.py                  # Typer root
     │   ├── config.py               # XDG TOML loader
     │   ├── side.py                 # Sol-vs-not-Sol guard
-    │   ├── slurm.py                # squeue/scancel/sbatch wrappers; jobid resolution
+    │   ├── slurm.py                # squeue/scancel/salloc/srun wrappers; jobid resolution
     │   ├── jobs.py                 # `solx job *`
     │   ├── keep.py                 # `solx keep`
     │   └── init.py                 # `solx init`
@@ -155,9 +155,14 @@ the existing `solx/` source tree live in
 - `solx keep` only touches files under directories the user has
   declared in `[keep]`. Mutates `atime`/`mtime` only — never reads,
   moves, or deletes content.
-- Mutating commands (`job start`, `job stop`, `keep`) print the
-  underlying Slurm/`touch` invocations they would run with
-  `--dry-run` first.
+- Destructive commands (`job stop`, `keep`) prompt for confirmation
+  by default; `-y` skips the prompt for scripts; `-n` / `--dry-run`
+  prints the planned action without executing (and without
+  prompting). `-y` and `-n` are mutually exclusive.
+- `job start` also has a `--dry-run` mode, but its purpose is
+  different — it prints the underlying `salloc` argv so the user can
+  preview the allocation request. No prompt either way (starting an
+  allocation isn't destructive in the data-loss sense).
 
 When laptop-side work returns (deferred), a fresh security review of
 that surface comes with it. Nothing in this stage commits us to a

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -116,7 +116,7 @@ genuinely needs TUI.
 | `solx job stop [JOBID]` | Cancel a job |
 | `solx job jump [JOBID]` (also `solx jump`) | Drop into a shell on the job's compute node |
 | `solx job time [JOBID]` | Remaining time (Slurm `D-HH:MM:SS`) |
-| `solx keep [--dry-run]` | Extend `/scratch` file mtimes for paths declared in config |
+| `solx keep [--stage S] [--csv-dir D] [-j N] [-n] [-v]` | Renew CSV-flagged scratch files filtered by `[keep]` (port of `sol_renew.py`) |
 | `solx config show` / `edit` | Inspect / edit the single TOML config |
 | `solx completions <shell>` | Emit shell completions |
 | `solx --version` / `--help` | — |

--- a/docs/stage-2-solx.md
+++ b/docs/stage-2-solx.md
@@ -57,7 +57,7 @@ Defaults wherever a sensible default exists.
 | `solx job stop [JOBID]` | Cancel a job | `scancel` |
 | `solx job jump [JOBID]` (also `solx jump`) | Drop into `default_shell` on the job's compute node | `srun --jobid=… --pty $shell` |
 | `solx job time [JOBID]` | Print time remaining in Slurm `D-HH:MM:SS` format | `squeue -h -j … -O TimeLeft` |
-| `solx keep [--dry-run]` | Touch mtimes on `[keep]` paths in config | `touch -a -m -c` |
+| `solx keep [--stage S] [--csv-dir DIR] [-j N] [-n] [-v]` | Renew CSV-flagged scratch files filtered by `[keep]` | `touch -a -m -c` |
 | `solx config show [--json]` | Print resolved config | — |
 | `solx config edit` | Open `config.toml` in `$EDITOR` | — |
 | `solx completions <bash\|zsh\|fish>` | Emit shell completion script | Typer built-in |
@@ -126,10 +126,11 @@ qos = "public"
 partition = "htc"
 time = "0-1"
 
-# Scratch paths to keep alive when `solx keep` runs.
+# Scratch paths to keep alive when Sol flags them in a warning CSV
+# *and* `solx keep` runs. Replace `sparky` with your ASURITE.
 # Examples (uncomment + edit):
 # [keep]
-# include = ["/scratch/<asurite>/your-project", "/scratch/<asurite>/experiments/**"]
+# include = ["/scratch/sparky/your-project", "/scratch/sparky/experiments/**"]
 # exclude = ["**/__pycache__", "**/.venv"]
 ```
 
@@ -169,13 +170,47 @@ run.
 | `side.py` | KEEP, simplify | Internal Sol-vs-not-Sol guard; no longer a top-level command. |
 | `slurm.py` | NEW | Thin `squeue`/`scancel`/`sbatch`/`srun` wrappers; `Job` dataclass; `resolve_jobid()` per the rules above. |
 | `jobs.py` | NEW | `list`, `start`, `stop`, `jump`, `time` command bodies. |
-| `keep.py` | NEW | Reads `[keep]` from config, walks include∖exclude with `pathspec`, calls `touch -a -m -c`. `--dry-run`. |
+| `keep.py` | NEW | Port of `sol_renew.py`. Reads Sol's warning CSVs from `--csv-dir`, intersects flagged paths with `[keep]` include/exclude (via `pathspec`), `touch -a -m -c` on the intersection. Mirrors `sol_renew.py`'s flag surface (`--stage`, `--csv-dir`, `-j`, `-n`, `-v`); drops `--solkeep` since `[keep]` lives in the main config. |
 | `init.py` | NEW | First-run: write starter config (no `whoami` substitution; placeholders only). |
 | `session.py` | DELETE | No more `session.json`; `squeue` is the source of truth. |
 | `sol_cmds.py` | DELETE | Logic split across `jobs.py` / `keep.py` / `init.py`. |
 
 `pyproject.toml` adds `pathspec` to runtime deps. Python ≥ 3.11
 unchanged.
+
+### Scratch renewal mechanism
+
+`solx keep` is a port of the existing `sol_renew.py` script. The
+mechanism is unchanged — only the keep-list source moves.
+
+1. Reads Sol's warning CSVs from `--csv-dir` (default `$HOME`):
+   - `scratch-dirs-pending-removal.csv` (most urgent)
+   - `scratch-dirs-over-90days.csv`
+   - `scratch-dirs-inactive.csv`
+2. Filters the flagged directories through `[keep]` include/exclude
+   from `config.toml` (via `pathspec`). Replaces `sol_renew.py`'s
+   `~/.solkeep` filter — same matching semantics, lives in the main
+   config now.
+3. `touch -a -m -c` only the directories that **both** appear in a
+   CSV and match `[keep]`. Never walks `/scratch` wholesale.
+
+Flag surface mirrors `sol_renew.py`:
+
+| Flag | Meaning |
+|---|---|
+| `--stage {pending,over90,inactive,all}` | Default `all`. Limits which CSVs are read. |
+| `--csv-dir DIR` | Default `$HOME`. Where Sol drops the warning CSVs. |
+| `-j N`, `--jobs N` | Default `min(8, ncpu//4)`. Parallel workers — NFS is the bottleneck so the default is conservative. |
+| `-n`, `--dry-run` | Print the plan without touching anything. |
+| `-v`, `--verbose` | Verbose plan + progress. |
+
+Dropped vs `sol_renew.py`: `--solkeep PATH` (the keep list now lives
+in `[keep]` in the main config, not a separate file).
+
+This preserves `sol_renew.py`'s ethical posture: only touches files
+Sol has explicitly flagged. `solx keep` cannot be used to bypass
+the scratch-retention policy by keeping arbitrary files alive on a
+cron — there's nothing to do until Sol drops a warning CSV.
 
 ## State tracking — none
 
@@ -210,9 +245,12 @@ per-run.
 7. **Default-jobid resolution**: on a compute node, `solx job time`
    (no arg) uses `$SLURM_JOB_ID`. On a login node with one job, no
    arg → that job. With ≥2 jobs, no arg → table + exit 2.
-8. **`solx keep --dry-run`** prints which paths would be touched per
-   `[keep]` include∖exclude; without `--dry-run`, mtimes update for
-   matched files only.
+8. **`solx keep`** mirrors `sol_renew.py`: reads Sol's warning CSVs
+   from `--csv-dir`, intersects flagged dirs with `[keep]`
+   include/exclude, `touch -a -m -c` on the intersection. Flag
+   surface (`--stage`, `--csv-dir`, `-j`, `-n`, `-v`) matches
+   `sol_renew.py` verbatim except the dropped `--solkeep`. With
+   `--dry-run`, prints the plan and touches nothing.
 9. **No `[keep]` block** → `solx keep` exits 2 with "no `[keep]`
    block in config; run `solx config edit` to add one".
 10. **`solx completions zsh`** emits a script that, when sourced,
@@ -249,7 +287,7 @@ Coverage targets:
 - **CLI dispatch**: every subcommand wired correctly via
   `typer.testing.CliRunner`.
 
-### Manual smoke on Sol (after `ssh swan16@sol.asu.edu`)
+### Manual smoke on Sol (after `ssh sparky@sol.asu.edu`, with your ASURITE)
 
 Tight on purpose — `htc`/`debug` queues in seconds.
 

--- a/docs/stage-2-solx.md
+++ b/docs/stage-2-solx.md
@@ -1,0 +1,289 @@
+# Stage 2 — Sol-only `solx` CLI
+
+Sub-plan of [PLAN.md](PLAN.md). This stage builds the `solx` CLI as
+a **Sol-first** tool: the user reaches Sol manually (per Stage 1's
+`references/sessions.md`), then runs `solx` from a login or compute
+node. All laptop-side work is deferred for further design discussion
+([PLAN.md §"Pivot"](PLAN.md#pivot--what-changed-and-why)).
+
+This stage does **not** touch `skills/sol-skill/`. The skill keeps
+shipping `sol_renew.py` and `.solkeep`-driven scratch renewal
+unchanged. From the skill's point of view, `solx` does not exist —
+that integration is Stage 3 and is deferred until the user
+greenlights it.
+
+## Scope
+
+In scope:
+
+- `solx/` package — full rewrite of the existing Stage 2a code
+  against the new command surface.
+- `docs/solx.md` — user manual rewritten for the new surface.
+- `docs/solx-smoke.md` — smoke checklist rewritten around `solx job
+  start`.
+- `solx/README.md` — minimal, links to `docs/solx.md`.
+
+Out of scope:
+
+- Anything under `skills/sol-skill/` — `SKILL.md`, `sol_renew.py`,
+  `.solkeep` syntax, references — all stay as shipped in v0.2.1.
+- Root `README.md` — primarily the skill's README, untouched.
+- `solx skill install/remove/list/update` subcommands — verbs
+  reserved for the eventual surface, **not implemented in this
+  stage**. They return with Stage 3.
+- Laptop-side everything — `solx up/down/forward/info`, `solx init`
+  on a laptop, `~/.config/solx/laptop.toml`, ssh-chain
+  construction, ControlMaster, `~/.ssh/*` reads. Deferred.
+
+## Command surface
+
+Noun-verb groups for related operations; flags for leaf commands.
+Defaults wherever a sensible default exists.
+
+**Aliases**:
+
+- The `job` subgroup is also reachable as `jobs`, and `list` is also
+  reachable as `ls`. So `solx job list`, `solx jobs list`, `solx job
+  ls`, and `solx jobs ls` are all equivalent.
+- `jump` is also exposed as a top-level shortcut — `solx jump
+  [JOBID]` is identical to `solx job jump [JOBID]`. It's the verb
+  used most often, so it earns the shortcut.
+
+| Command | What it does | Underlying |
+|---|---|---|
+| `solx init` | First-run: write a starter `config.toml` | — |
+| `solx job list` (alias `ls`) | Print my Sol jobs as a Rich table | `squeue -u $USER` |
+| `solx job start [TEMPLATE]` | Submit an interactive allocation, wait for `RUNNING`, print the jobid | `salloc --no-shell` (Slurm ≥ 22.05; Sol runs 25.x) |
+| `solx job stop [JOBID]` | Cancel a job | `scancel` |
+| `solx job jump [JOBID]` (also `solx jump`) | Drop into `default_shell` on the job's compute node | `srun --jobid=… --pty $shell` |
+| `solx job time [JOBID]` | Print time remaining in Slurm `D-HH:MM:SS` format | `squeue -h -j … -O TimeLeft` |
+| `solx keep [--dry-run]` | Touch mtimes on `[keep]` paths in config | `touch -a -m -c` |
+| `solx config show [--json]` | Print resolved config | — |
+| `solx config edit` | Open `config.toml` in `$EDITOR` | — |
+| `solx completions <bash\|zsh\|fish>` | Emit shell completion script | Typer built-in |
+| `solx --version`, `--help` | — | — |
+
+`solx where` from Stage 2a is dropped — Sol-only is implicit; a
+not-Sol guard fires from each subcommand instead. The `session`
+subgroup, the `[shared]` config merge, and all laptop-side stubs are
+removed.
+
+### Default jobid resolution
+
+When `[JOBID]` is omitted from `stop` / `jump` / `time`:
+
+1. Argument given → use it.
+2. Else `$SLURM_JOB_ID` set → use it (compute-node default).
+3. Else query `squeue -u $USER`:
+   - 0 jobs → exit 1, "no jobs found".
+   - 1 job → use it.
+   - ≥2 jobs → print a Rich table of all jobs, exit 2 with "specify
+     a jobid: `solx job stop <jobid>`". Non-interactive on purpose
+     — confirmation prompts make cancel-the-wrong-job too easy.
+
+`solx job start` does not take `[JOBID]`; its argument is a
+`[TEMPLATE]` name that defaults to `default_template` from config.
+
+### Allocation mechanism
+
+`solx job start` uses `salloc --no-shell` (Slurm 22.05+; Sol runs
+25.x). salloc waits for the queue, then exits with the allocation
+left running in the background. We parse the jobid from salloc's
+stderr (`salloc: Granted job allocation N`) and return it.
+
+The earlier prototype used `sbatch --parsable --wrap='sleep
+infinity'`; we switch to `salloc --no-shell` because:
+
+- Native Slurm primitive — no `sleep` workaround, no CPU time
+  billed to a sleeper process, clean `seff` output.
+- `--parsable` isn't needed because we capture the jobid from
+  stderr rather than stdout.
+- Same end state: a running allocation the user attaches to via
+  `solx job jump` (which wraps `srun --jobid=… --pty $shell`).
+
+The blocking-during-queue-wait behavior is intentional — `solx job
+start` is meant to return only when the allocation is RUNNING and
+ready for `solx job jump`. `start_timeout` (config, with
+`--timeout` override) caps the wait so a stuck queue surfaces
+instead of hanging.
+
+## Configuration
+
+Single file under `$XDG_CONFIG_HOME/solx/config.toml` (fallback
+`~/.config/solx/config.toml`). Created mode 0600.
+
+```toml
+default_shell = "zsh"
+default_template = "default"
+start_timeout = "10m"          # cap on `job start` polling; --timeout overrides
+
+[jobs.default]
+partition = "lightwork"
+time = "1-0"
+qos = "public"
+
+[jobs.debug]
+partition = "htc"
+time = "0-1"
+
+# Scratch paths to keep alive when `solx keep` runs.
+# Examples (uncomment + edit):
+# [keep]
+# include = ["/scratch/<asurite>/your-project", "/scratch/<asurite>/experiments/**"]
+# exclude = ["**/__pycache__", "**/.venv"]
+```
+
+Schema:
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `default_shell` | string | yes | Used by `solx job jump` when dropping into the compute node. |
+| `default_template` | string | yes | Template name used when `solx job start` has no argument. |
+| `start_timeout` | string (e.g. `"10m"`) | no, default `"10m"` | Polling cap for `job start`; `--timeout` flag overrides. |
+| `[jobs.<name>]` | table | yes (≥1) | Job templates. Each table is a slurm flag set. |
+| `[jobs.<name>].partition` | string | yes | `-p` |
+| `[jobs.<name>].time` | string | yes | `-t` |
+| `[jobs.<name>].qos` | string | no | `-q` |
+| `[jobs.<name>].gres` | string | no | `--gres` |
+| `[jobs.<name>].extra_args` | array of strings | no | Verbatim sbatch flags (e.g. `["--mem=64G", "--mail-type=END"]`). |
+| `[keep]` | table | no | Scratch renewal config; absent = `solx keep` is a no-op. |
+| `[keep].include` | array of glob strings | yes when `[keep]` present | Recursive globs (`**` supported via `pathspec`). |
+| `[keep].exclude` | array of glob strings | no | Carve-outs from `include`. |
+
+No `[shared]` merge. Each `[jobs.<name>]` is self-contained — repeat
+flags across templates if needed. Simpler config is the trade.
+
+CLI passthrough: anything after `--` on `solx job start` is appended
+to the underlying sbatch command after `extra_args`. Sbatch's
+last-flag-wins lets the tail override template defaults for one
+run.
+
+## Source layout (`solx/src/solx/`)
+
+| File | Action | Notes |
+|---|---|---|
+| `__init__.py` | KEEP | Version constant. |
+| `__main__.py` | KEEP | `python -m solx`. |
+| `cli.py` | REWRITE | Typer root with `job` subgroup, top-level `keep`, `init`, `config` subgroup, `completions`. Drop `where`, `session` group, all laptop stubs. |
+| `config.py` | REWRITE | Load `$XDG_CONFIG_HOME/solx/config.toml`. New schema (above). No `[shared]` merge. |
+| `side.py` | KEEP, simplify | Internal Sol-vs-not-Sol guard; no longer a top-level command. |
+| `slurm.py` | NEW | Thin `squeue`/`scancel`/`sbatch`/`srun` wrappers; `Job` dataclass; `resolve_jobid()` per the rules above. |
+| `jobs.py` | NEW | `list`, `start`, `stop`, `jump`, `time` command bodies. |
+| `keep.py` | NEW | Reads `[keep]` from config, walks include∖exclude with `pathspec`, calls `touch -a -m -c`. `--dry-run`. |
+| `init.py` | NEW | First-run: write starter config (no `whoami` substitution; placeholders only). |
+| `session.py` | DELETE | No more `session.json`; `squeue` is the source of truth. |
+| `sol_cmds.py` | DELETE | Logic split across `jobs.py` / `keep.py` / `init.py`. |
+
+`pyproject.toml` adds `pathspec` to runtime deps. Python ≥ 3.11
+unchanged.
+
+## State tracking — none
+
+`squeue -u $USER` is queried each invocation. No persistent state
+file, no stale-session edge cases. Rationale: `squeue` is fast on a
+login node, and "what jobs do I have" is a question Slurm already
+answers authoritatively.
+
+`start_timeout` exists as a failsafe so `solx job start` never hangs
+forever on a stuck queue. Default 10 min; `--timeout` flag overrides
+per-run.
+
+## Success criteria
+
+1. **Installs on Sol**: `uv tool install ./solx` succeeds; `solx
+   --version` works in a fresh shell.
+2. **Sol guard**: every subcommand exits 2 with a clear "solx is
+   Sol-only — SSH to Sol first" message on a non-Sol host. No stack
+   trace.
+3. **Config round-trip**: `solx init` writes a starter config; `solx
+   config show` prints it back; `solx config edit` opens it in
+   `$EDITOR`.
+4. **`solx job list`** prints a Rich table matching `squeue -u
+   $USER` content (jobid, name, state, time, time-left, partition).
+5. **`solx job start <template> --dry-run`** prints the literal
+   sbatch argv without submitting; structure is snapshot-tested per
+   template.
+6. **`solx job start <template>`** lifecycle on `htc`/`debug`
+   completes in <2 min: submit → poll → print jobid. `solx job
+   shell` drops into `default_shell` on the compute node. `solx job
+   time` prints remaining. `solx job stop` cancels.
+7. **Default-jobid resolution**: on a compute node, `solx job time`
+   (no arg) uses `$SLURM_JOB_ID`. On a login node with one job, no
+   arg → that job. With ≥2 jobs, no arg → table + exit 2.
+8. **`solx keep --dry-run`** prints which paths would be touched per
+   `[keep]` include∖exclude; without `--dry-run`, mtimes update for
+   matched files only.
+9. **No `[keep]` block** → `solx keep` exits 2 with "no `[keep]`
+   block in config; run `solx config edit` to add one".
+10. **`solx completions zsh`** emits a script that, when sourced,
+    autocompletes subcommands and template names.
+11. **Alias coverage**: `solx jobs list`, `solx jobs ls`, `solx job
+    ls`, and `solx jump` all dispatch to the right command (covered
+    by `typer.testing.CliRunner` tests).
+12. **Tests pass**: `cd solx && uv run pytest -v` is green.
+13. **Skill untouched**: `git diff main..HEAD -- skills/` is empty.
+
+## Testing
+
+### Unit tests (run anywhere — no Sol required)
+
+```shell
+cd solx && uv run pytest -v
+```
+
+Coverage targets:
+
+- **Config parsing**: required keys, type errors, missing
+  `default_template`, `[keep]` include/exclude merge, glob
+  compilation via `pathspec`.
+- **Side detection**: faked `hostname -a` outputs for Sol login,
+  Sol compute, not-Sol. All three branches.
+- **Argv construction**: snapshot-test the rendered `sbatch` argv
+  per template × `--dry-run` × `-- passthrough` combinations.
+- **Default jobid resolution**: arg / env / single-job / multi-job
+  branches with mocked `squeue`.
+- **`keep` glob matching**: include∖exclude correctness on a synthetic
+  scratch tree fixture.
+- **`solx job list`** rendering against a faked `squeue` output
+  (1 job, multiple jobs, no jobs, queued vs running).
+- **CLI dispatch**: every subcommand wired correctly via
+  `typer.testing.CliRunner`.
+
+### Manual smoke on Sol (after `ssh swan16@sol.asu.edu`)
+
+Tight on purpose — `htc`/`debug` queues in seconds.
+
+1. Install: `uv tool install ./solx` from a checkout, or
+   `uv tool install git+...#subdirectory=solx`. `solx --version`.
+2. `solx init` — writes starter config; `solx config show` prints
+   it.
+3. `$EDITOR ~/.config/solx/config.toml` — fill in a real `[keep]`
+   include path you actually own.
+4. `solx job start debug --dry-run` — prints sbatch argv.
+5. `solx job start debug` — submits, polls, prints jobid in <30s.
+6. `solx job list` — table includes the new job, state RUNNING.
+7. `solx job time` — prints remaining (no arg, login node, one job
+   → uses it).
+8. `solx job jump` — drops into `default_shell` on the compute
+   node. `exit` returns to login.
+9. `solx job stop` — `scancel`s; `solx job list` shows the job
+   gone.
+10. `solx keep --dry-run` — prints paths that would be touched.
+11. `solx keep` — touches mtimes; `stat` on a sample file shows
+    updated mtime.
+12. Wrong-side guard: same commands on a laptop → all exit 2 with
+    the redirect message. `solx --version` and `solx --help` work
+    anywhere.
+
+## Sequencing within Stage 2
+
+PR #1 (this branch, `docs/sol-first-pivot`): docs only — `PLAN.md`,
+`stage-2-solx.md`, `stage-3-integration.md`. Locks the contract.
+
+PR #2 (`feat/sol-first-cli`, future): `solx/` rewrite + `docs/solx.md`
++ `docs/solx-smoke.md` + `solx/README.md`, against this contract.
+Smoke on Sol before merge. Skill files untouched.
+
+PR #5 (the existing Stage 2a PR, `feat/stage-2a-solx-sol-only`): left
+open during PR #1 and PR #2; closed after PR #2 lands, with a comment
+pointing at the new direction.

--- a/docs/stage-2-solx.md
+++ b/docs/stage-2-solx.md
@@ -54,10 +54,10 @@ Defaults wherever a sensible default exists.
 | `solx init` | First-run: write a starter `config.toml` | — |
 | `solx job list` (alias `ls`) | Print my Sol jobs as a Rich table | `squeue -u $USER` |
 | `solx job start [TEMPLATE]` | Submit an interactive allocation, wait for `RUNNING`, print the jobid | `salloc --no-shell` (Slurm ≥ 22.05; Sol runs 25.x) |
-| `solx job stop [JOBID]` | Cancel a job | `scancel` |
+| `solx job stop [JOBID] [-y] [-n]` | Cancel a job (prompts unless `-y`; `-n` previews) | `scancel` |
 | `solx job jump [JOBID]` (also `solx jump`) | Drop into `default_shell` on the job's compute node | `srun --jobid=… --pty $shell` |
 | `solx job time [JOBID]` | Print time remaining in Slurm `D-HH:MM:SS` format | `squeue -h -j … -O TimeLeft` |
-| `solx keep [--stage S] [--csv-dir DIR] [-j N] [-n] [-v]` | Renew CSV-flagged scratch files filtered by `[keep]` | `touch -a -m -c` |
+| `solx keep [--stage S] [--csv-dir DIR] [-j N] [-y] [-n] [-v]` | Renew CSV-flagged scratch files filtered by `[keep]` (prompts unless `-y`; `-n` previews) | `touch -a -m -c` |
 | `solx config show [--json]` | Print resolved config | — |
 | `solx config edit` | Open `config.toml` in `$EDITOR` | — |
 | `solx completions <bash\|zsh\|fish>` | Emit shell completion script | Typer built-in |
@@ -212,6 +212,31 @@ Sol has explicitly flagged. `solx keep` cannot be used to bypass
 the scratch-retention policy by keeping arbitrary files alive on a
 cron — there's nothing to do until Sol drops a warning CSV.
 
+### Destructive commands
+
+`solx job stop` and `solx keep` mutate cluster or filesystem state
+— cancelling a running allocation, or `touch`ing mtimes under
+`/scratch`. Both follow the same prompt-by-default contract:
+
+| Flag | Behavior |
+|---|---|
+| (none) | Print what's about to happen, then prompt `Proceed? [y/N]` (Rich `Confirm.ask`, default no). User must type `y` to continue. |
+| `-y`, `--yes` | Skip the prompt and execute. For scripts and unattended automation. |
+| `-n`, `--dry-run` | Print the plan without executing. **No prompt** — nothing destructive is about to happen, so confirming would be noise. |
+
+`-y` and `-n` are mutually exclusive — passing both exits 2 with a
+"can't both confirm and dry-run" error.
+
+The other commands (`init`, `job start`, `job list`, `job jump`,
+`job time`, `config show`, `config edit`, `completions`) are
+non-destructive or self-evidently interactive (the user typed
+`solx job start gpu` — they're not surprised when something starts).
+They don't prompt.
+
+`solx init` does prompt before overwriting an existing
+`config.toml`, but that's specific to that command and not part of
+the general destructive-command contract.
+
 ## State tracking — none
 
 `squeue -u $USER` is queried each invocation. No persistent state
@@ -253,13 +278,17 @@ per-run.
    `--dry-run`, prints the plan and touches nothing.
 9. **No `[keep]` block** → `solx keep` exits 2 with "no `[keep]`
    block in config; run `solx config edit` to add one".
-10. **`solx completions zsh`** emits a script that, when sourced,
+10. **Destructive-command confirmation contract**: `solx job stop`
+    and `solx keep` prompt by default; `-y` skips; `-n` previews
+    without prompt; `-y -n` together exits 2. Covered by
+    `typer.testing.CliRunner` tests with mocked `Confirm.ask`.
+11. **`solx completions zsh`** emits a script that, when sourced,
     autocompletes subcommands and template names.
-11. **Alias coverage**: `solx jobs list`, `solx jobs ls`, `solx job
+12. **Alias coverage**: `solx jobs list`, `solx jobs ls`, `solx job
     ls`, and `solx jump` all dispatch to the right command (covered
     by `typer.testing.CliRunner` tests).
-12. **Tests pass**: `cd solx && uv run pytest -v` is green.
-13. **Skill untouched**: `git diff main..HEAD -- skills/` is empty.
+13. **Tests pass**: `cd solx && uv run pytest -v` is green.
+14. **Skill untouched**: `git diff main..HEAD -- skills/` is empty.
 
 ## Testing
 
@@ -304,11 +333,13 @@ Tight on purpose — `htc`/`debug` queues in seconds.
    → uses it).
 8. `solx job jump` — drops into `default_shell` on the compute
    node. `exit` returns to login.
-9. `solx job stop` — `scancel`s; `solx job list` shows the job
-   gone.
-10. `solx keep --dry-run` — prints paths that would be touched.
-11. `solx keep` — touches mtimes; `stat` on a sample file shows
-    updated mtime.
+9. `solx job stop` — prompts `Cancel job N? [y/N]`; type `y`;
+   `scancel` runs; `solx job list` shows the job gone. Re-run with
+   `-y` once and confirm no prompt.
+10. `solx keep --dry-run` — prints paths that would be touched. No
+    prompt (dry-run skips it).
+11. `solx keep` — prompts `Touch mtimes on N directories? [y/N]`;
+    type `y`; `stat` on a sample file shows updated mtime.
 12. Wrong-side guard: same commands on a laptop → all exit 2 with
     the redirect message. `solx --version` and `solx --help` work
     anywhere.

--- a/docs/stage-2-solx.md
+++ b/docs/stage-2-solx.md
@@ -146,8 +146,8 @@ Schema:
 | `[jobs.<name>].time` | string | yes | `-t` |
 | `[jobs.<name>].qos` | string | no | `-q` |
 | `[jobs.<name>].gres` | string | no | `--gres` |
-| `[jobs.<name>].extra_args` | array of strings | no | Verbatim sbatch flags (e.g. `["--mem=64G", "--mail-type=END"]`). |
-| `[keep]` | table | no | Scratch renewal config; absent = `solx keep` is a no-op. |
+| `[jobs.<name>].extra_args` | array of strings | no | Verbatim Slurm flags passed to `salloc` (e.g. `["--mem=64G", "--mail-type=END"]`). |
+| `[keep]` | table | no | Scratch renewal config. If absent, `solx keep` exits 2 with "no `[keep]` block; run `solx config edit`" (see success criterion #9). |
 | `[keep].include` | array of glob strings | yes when `[keep]` present | Recursive globs (`**` supported via `pathspec`). |
 | `[keep].exclude` | array of glob strings | no | Carve-outs from `include`. |
 
@@ -155,7 +155,7 @@ No `[shared]` merge. Each `[jobs.<name>]` is self-contained — repeat
 flags across templates if needed. Simpler config is the trade.
 
 CLI passthrough: anything after `--` on `solx job start` is appended
-to the underlying sbatch command after `extra_args`. Sbatch's
+to the underlying `salloc` command after `extra_args`. Slurm's
 last-flag-wins lets the tail override template defaults for one
 run.
 
@@ -168,7 +168,7 @@ run.
 | `cli.py` | REWRITE | Typer root with `job` subgroup, top-level `keep`, `init`, `config` subgroup, `completions`. Drop `where`, `session` group, all laptop stubs. |
 | `config.py` | REWRITE | Load `$XDG_CONFIG_HOME/solx/config.toml`. New schema (above). No `[shared]` merge. |
 | `side.py` | KEEP, simplify | Internal Sol-vs-not-Sol guard; no longer a top-level command. |
-| `slurm.py` | NEW | Thin `squeue`/`scancel`/`sbatch`/`srun` wrappers; `Job` dataclass; `resolve_jobid()` per the rules above. |
+| `slurm.py` | NEW | Thin `squeue`/`scancel`/`salloc`/`srun` wrappers; `Job` dataclass; `resolve_jobid()` per the rules above. |
 | `jobs.py` | NEW | `list`, `start`, `stop`, `jump`, `time` command bodies. |
 | `keep.py` | NEW | Port of `sol_renew.py`. Reads Sol's warning CSVs from `--csv-dir`, intersects flagged paths with `[keep]` include/exclude (via `pathspec`), `touch -a -m -c` on the intersection. Mirrors `sol_renew.py`'s flag surface (`--stage`, `--csv-dir`, `-j`, `-n`, `-v`); drops `--solkeep` since `[keep]` lives in the main config. |
 | `init.py` | NEW | First-run: write starter config (no `whoami` substitution; placeholders only). |
@@ -261,12 +261,13 @@ per-run.
 4. **`solx job list`** prints a Rich table matching `squeue -u
    $USER` content (jobid, name, state, time, time-left, partition).
 5. **`solx job start <template> --dry-run`** prints the literal
-   sbatch argv without submitting; structure is snapshot-tested per
-   template.
+   `salloc` argv without submitting; structure is snapshot-tested
+   per template.
 6. **`solx job start <template>`** lifecycle on `htc`/`debug`
-   completes in <2 min: submit → poll → print jobid. `solx job
-   shell` drops into `default_shell` on the compute node. `solx job
-   time` prints remaining. `solx job stop` cancels.
+   completes in <2 min: submit → wait for grant → print jobid.
+   `solx job jump` drops into `default_shell` on the compute node.
+   `solx job time` prints remaining. `solx job stop` cancels (with
+   confirmation prompt; `-y` skips).
 7. **Default-jobid resolution**: on a compute node, `solx job time`
    (no arg) uses `$SLURM_JOB_ID`. On a login node with one job, no
    arg → that job. With ≥2 jobs, no arg → table + exit 2.
@@ -305,7 +306,7 @@ Coverage targets:
   compilation via `pathspec`.
 - **Side detection**: faked `hostname -a` outputs for Sol login,
   Sol compute, not-Sol. All three branches.
-- **Argv construction**: snapshot-test the rendered `sbatch` argv
+- **Argv construction**: snapshot-test the rendered `salloc` argv
   per template × `--dry-run` × `-- passthrough` combinations.
 - **Default jobid resolution**: arg / env / single-job / multi-job
   branches with mocked `squeue`.
@@ -326,8 +327,9 @@ Tight on purpose — `htc`/`debug` queues in seconds.
    it.
 3. `$EDITOR ~/.config/solx/config.toml` — fill in a real `[keep]`
    include path you actually own.
-4. `solx job start debug --dry-run` — prints sbatch argv.
-5. `solx job start debug` — submits, polls, prints jobid in <30s.
+4. `solx job start debug --dry-run` — prints `salloc` argv.
+5. `solx job start debug` — submits, waits for the queue grant,
+   prints jobid in <30s.
 6. `solx job list` — table includes the new job, state RUNNING.
 7. `solx job time` — prints remaining (no arg, login node, one job
    → uses it).

--- a/docs/stage-3-integration.md
+++ b/docs/stage-3-integration.md
@@ -1,0 +1,108 @@
+# Stage 3 — Skill ↔ `solx` integration (deferred)
+
+Sub-plan of [PLAN.md](PLAN.md). **Deferred until Stage 2 is mature
+and the user has greenlit skill integration.** Until then, do not
+touch any file under `skills/sol-skill/`.
+
+## Why deferred
+
+Stage 2 (`solx` CLI) is in active design and rewrite. Stitching the
+agent skill to a CLI that's still in flux means doing the
+integration work twice. Worse, premature integration risks teaching
+the agent commands that get renamed or removed before Stage 2
+stabilizes.
+
+The skill currently teaches `sol_renew.py` for scratch renewal and
+the manual SSH chain for sessions. That is **complete and works
+end-to-end** on its own — there is no user-facing gap that demands
+Stage 3 ship sooner.
+
+## Greenlight criteria
+
+Stage 3 work begins only after **all** of the following hold:
+
+1. Stage 2 (`solx` CLI) has shipped and survived real Sol use — at
+   least one full lifecycle smoke (`init` → `job start` → `jump` →
+   `time` → `stop` → `keep`) verified live, and ideally a few days
+   of dogfooding.
+2. The CLI command surface is stable. No pending renames, no
+   deferred verbs that need to slot in. If `solx skill *` is going
+   to land, it lands here.
+3. The user explicitly says "ok, do Stage 3."
+
+## What Stage 3 will contain (when it returns)
+
+This list is provisional. The exact contents get re-litigated when
+the time comes, against the actual stable state of `solx`.
+
+### Likely in scope
+
+- **`skills/sol-skill/references/solx.md`** — new reference doc
+  walking the agent through the `solx`-driven workflow: `solx init`,
+  `solx job list/start/shell/time/stop`, `solx keep`. Includes a
+  config example and the `--dry-run`-first ethos.
+- **`skills/sol-skill/SKILL.md`** — add a `command -v solx`
+  detection branch under "Sessions" / "Submitting Jobs" / "Scratch
+  Renewal" sections so the agent prefers `solx` when present and
+  falls back to manual / `sol_renew.py` when not. The manual branch
+  stays — it never goes away.
+- **`skills/sol-skill/scripts/sol_renew.py`** — likely **kept**, not
+  removed. The skill's no-CLI flow stays viable as a fallback. May
+  get a note pointing at `solx keep` for users who have the CLI.
+- **`solx skill install/remove/list` subcommands** — the deferred
+  CLI verbs that `solx config init` / `solx init` couldn't include
+  in Stage 2. Likely a thin shell-out to `gh skill install` / Vercel
+  `skills add`, supporting `claude` and `codex` agents. Implementation
+  details (own path mapping vs delegate to existing CLI) decided at
+  the time.
+- **Root `README.md`** — possibly reframed to lead with both `solx`
+  and the skill as paired tools. Or left skill-primary if `solx`
+  hasn't earned top billing yet. Decided when Stage 3 starts.
+- **`docs/coverage.md`** — new rows for `solx`-detection-branch
+  behaviors, flipping from ⚪ roadmap to 🟡 documented or 🟢
+  tested as evals catch up.
+- **`CHANGELOG.md`** — a minor skill version bump describing the
+  new branch.
+
+### Likely out of scope (still)
+
+- **Laptop-side `solx`** — `solx up/down/forward/info`,
+  `~/.config/solx/laptop.toml`, ssh-chain construction. Still
+  deferred for further design discussion separate from Stage 3.
+- **Repo rename or PyPI publication** — release-engineering work is
+  a different track.
+
+## Success criteria (when Stage 3 ships)
+
+Provisional, finalized at greenlight time:
+
+1. With `solx` installed on Sol, the agent answers "start an
+   interactive job for me" by running `solx job start <template>`
+   (after `--dry-run` preview), not the manual `interactive` /
+   `sbatch` chain.
+2. With `solx` absent (uninstalled or fresh container), the agent
+   re-detects on the next prompt and falls back to the manual flow
+   from `sessions.md` and `slurm.md` cleanly.
+3. With `solx` installed and a `[keep]` block configured, the agent
+   answers "keep my scratch alive" by running `solx keep --dry-run`
+   then `solx keep`. With `solx` absent, it falls back to
+   `sol_renew.py` per the existing `references/scratch.md`.
+4. No content from `solx/README.md` or `docs/solx.md` is duplicated
+   into `references/solx.md`. The reference teaches the agent
+   *workflow*; the docs teach the user *configuration*. Two sources
+   of truth diverge.
+5. `git diff` shows zero changes to the existing `sol_renew.py`
+   behavior. Path remains supported.
+
+## Until then
+
+Treat Stage 3 as a closed door:
+
+- Do not edit `skills/sol-skill/SKILL.md`.
+- Do not add `references/solx.md`.
+- Do not remove or modify `scripts/sol_renew.py`.
+- Do not reframe root `README.md`.
+- Do not bump skill version in `CHANGELOG.md`.
+
+The skill ships v0.2.1 and that's the released line until Stage 3
+work is greenlit and ships its own version bump.

--- a/docs/stage-3-integration.md
+++ b/docs/stage-3-integration.md
@@ -39,8 +39,9 @@ the time comes, against the actual stable state of `solx`.
 
 - **`skills/sol-skill/references/solx.md`** — new reference doc
   walking the agent through the `solx`-driven workflow: `solx init`,
-  `solx job list/start/shell/time/stop`, `solx keep`. Includes a
-  config example and the `--dry-run`-first ethos.
+  `solx job list/start/jump/time/stop`, `solx keep`. Includes a
+  config example and the `-y`/`-n` confirmation contract for
+  destructive ops.
 - **`skills/sol-skill/SKILL.md`** — add a `command -v solx`
   detection branch under "Sessions" / "Submitting Jobs" / "Scratch
   Renewal" sections so the agent prefers `solx` when present and
@@ -50,11 +51,11 @@ the time comes, against the actual stable state of `solx`.
   removed. The skill's no-CLI flow stays viable as a fallback. May
   get a note pointing at `solx keep` for users who have the CLI.
 - **`solx skill install/remove/list` subcommands** — the deferred
-  CLI verbs that `solx config init` / `solx init` couldn't include
-  in Stage 2. Likely a thin shell-out to `gh skill install` / Vercel
-  `skills add`, supporting `claude` and `codex` agents. Implementation
-  details (own path mapping vs delegate to existing CLI) decided at
-  the time.
+  CLI verbs that `solx init` couldn't include in Stage 2. Likely a
+  thin shell-out to `gh skill install` / Vercel `skills add`,
+  supporting `claude` and `codex` agents. Implementation details
+  (own path mapping vs delegate to existing CLI) decided at the
+  time.
 - **Root `README.md`** — possibly reframed to lead with both `solx`
   and the skill as paired tools. Or left skill-primary if `solx`
   hasn't earned top billing yet. Decided when Stage 3 starts.
@@ -100,7 +101,7 @@ Treat Stage 3 as a closed door:
 
 - Do not edit `skills/sol-skill/SKILL.md`.
 - Do not add `references/solx.md`.
-- Do not remove or modify `scripts/sol_renew.py`.
+- Do not remove or modify `skills/sol-skill/scripts/sol_renew.py`.
 - Do not reframe root `README.md`.
 - Do not bump skill version in `CHANGELOG.md`.
 


### PR DESCRIPTION
PR #1 of two for the `solx` rewrite. **Doc-only** — locks the contract for PR #2 (the `solx/` code rewrite). No code changes here.

## Why

Earlier the plan was to grow `solx` into a "one magic command from laptop" path (Stage 2b). That vision threads ssh-client behavior, ControlMaster, Duo, and Slurm queue-wait races — none of which are unit-testable. Better to defer the laptop side entirely until the design is re-thought from scratch.

Net change: **Stage 2 is now Sol-only, full stop.** The user reaches Sol manually (per Stage 1's `references/sessions.md`), then runs `solx` from there. Skill files stay completely untouched until Stage 3 is greenlit.

## What's in this PR

- `docs/PLAN.md` — rewritten around Sol-first principles. New command surface table, deferred Stage 3, decisions confirmed.
- `docs/stage-2-solx.md` — **new file**: full sub-plan with command surface, single TOML config schema, source-layout deltas (`jobs.py`/`keep.py`/`init.py`/`slurm.py` NEW; `session.py`/`sol_cmds.py` DELETE), default jobid resolution, success criteria, smoke checklist.
- `docs/stage-3-integration.md` — **new file**: marker for skill ↔ CLI integration. Deferred until user greenlight; lists what'll be in scope when it returns.

## Command surface (locked by this PR)

| Command | What |
|---|---|
| `solx init` | First-run config |
| `solx job list` (`ls`; group `jobs`) | List my Sol jobs |
| `solx job start [TEMPLATE]` | Interactive allocation (`salloc --no-shell`) |
| `solx job stop [JOBID]` | Cancel |
| `solx job jump [JOBID]` (also `solx jump`) | Drop into shell on compute node |
| `solx job time [JOBID]` | Remaining time |
| `solx keep [--dry-run]` | Touch mtimes per `[keep]` |
| `solx config show` / `edit` | Inspect / edit |
| `solx completions <shell>` | Emit completions |

## Out of scope (deliberate)

- `skills/sol-skill/` — untouched. Keeps shipping `sol_renew.py` + `.solkeep`. Stage 3 deferred.
- `solx skill install/remove/list` — verbs reserved, not implemented in this stage.
- Laptop-side anything — deferred for further design discussion.
- `solx/` source code — rewritten in PR #2.
- `docs/solx.md`, `docs/solx-smoke.md`, `solx/README.md` — rewritten in PR #2 (would diverge from current `session`-verb code if updated now).

## Test plan

- [ ] Read each doc end-to-end; confirm it matches the agreed-upon design.
- [ ] No code changes — nothing to run, lint, or smoke.
- [ ] After merge: open PR #2 against this contract.

## Related

- Tracking issue: **#4** (title and body updated to match this pivot).
- Addresses (in part) **#7** (Sol Config — single XDG TOML, `default_shell`, `[jobs.*]` templates) and **#11** (submit/monitor jobs — `solx job start/list/time`). Closes PR #2 ships the implementation.
- **#9** (helpful slurm commands) and **#10** (Sol AI) are orthogonal to this stage.
- PR **#5** (`feat/stage-2a-solx-sol-only`) — stays open through PR #14 + PR #2 review; closed after PR #2 lands with a comment pointing at the new direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)