### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ tag for that release.
 
 ## [Unreleased]
 
-(Changes since v0.2.1 land here. Move them under a new heading on release.)
+(Changes since v0.3.0 land here. Move them under a new heading on release.)
+
+## [0.3.0] — 2026-05-28
+
+File-level scratch renewal, faster enumeration, and skill guidance for
+where to run it. Closes #17 (see #18).
 
 ### Changed
 
@@ -24,7 +29,7 @@ tag for that release.
   slowest single directory, not just the count of directories.
   Plan/dry-run output is unchanged; exit codes stay `0`/`1`/`2`, with
   `1` now reflecting an enumeration or touch-batch failure rather than
-  a per-directory one. Addresses #17.
+  a per-directory one.
 - `scripts/sol_renew.py`: enumeration prefers `fd` (then `rg --files`)
   when on `PATH`, falling back to `find` — the multithreaded walk is
   faster on a large directory. Run with `--hidden --no-ignore` so the
@@ -34,13 +39,31 @@ tag for that release.
 - `skills/sol-skill/SKILL.md`: add a "Where to run it" decision rule —
   a renewal is metadata-heavy I/O that Sol login nodes throttle, so on
   a login node run the heavy pass on the DTN (`ssh soldtn`), a compute
-  node, or a short `htc` job; match `-j` to the node's cores. (Keeps
-  implementation detail out of the skill — that lives in the
-  reference.)
+  node, or a short `htc` job; match `-j` to the node's cores.
+- `skills/sol-skill/SKILL.md`: rewrite the frontmatter `description`
+  for triggering — cover the scratch-renewal flow (previously omitted)
+  alongside the other domains, with an explicit near-miss guard
+  (generic SLURM/HPC on Phoenix/NERSC, cloud GPUs, local-laptop
+  tasks). Add a load-bearing safety rule: preview with `--dry-run` or
+  confirm scope before the mutating run.
+- `skills/sol-skill/SKILL.md`: the example `.solkeep` now carves out
+  regenerable trees (`.venv`/`.git`/`__pycache__`/`node_modules`)
+  under every kept path, with the reasoning — renewing them spends the
+  pass on files that rebuild for free.
 - `references/scratch.md`: document the streaming/file-level design,
   the `fd`/`rg`/`find` lister selection, the per-batch failure
   granularity, and the non-interactive `uv`-on-`PATH` gotcha for
   `ssh soldtn`.
+
+### Added
+
+- `evals/runner/run_l2_renew.py`: a runnable L2 eval that builds its
+  own sandbox (real files + stale mtimes, incl. `.venv`/`__pycache__`)
+  and asserts the renewal's filesystem mutations — dry-run touches
+  nothing, kept files refresh recursively, `.solkeep` carve-outs are
+  left alone, non-kept dirs are skipped. Closes the gap where the
+  static mock CSVs (absolute `/scratch` paths) couldn't prove real
+  touching.
 
 ### Deferred
 
@@ -166,7 +189,8 @@ agentskills.io-compatible layout (skill content under
 CSV-driven `/scratch` renewal, and shipped the original references
 (`module.md`, `scratch.md`, `sharing.md`, `slurm.md`).
 
-[Unreleased]: https://github.com/Shu-Wan/sol-skills/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/Shu-Wan/sol-skills/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/Shu-Wan/sol-skills/releases/tag/v0.3.0
 [0.2.1]: https://github.com/Shu-Wan/sol-skills/releases/tag/v0.2.1
 [0.2.0]: https://github.com/Shu-Wan/sol-skills/releases/tag/v0.2.0
 [0.1.0]: https://github.com/Shu-Wan/sol-skills/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ sol-skills/
 ## Verification and contributing
 
 - **Version history** — see [`CHANGELOG.md`](CHANGELOG.md). Current
-  release: v0.2.1.
+  release: v0.3.0.
 - **What's tested and how** — see [`docs/coverage.md`](docs/coverage.md)
   for the public methodology and per-area coverage matrix.
 - **Contributing / eval harness internals** — see
@@ -226,7 +226,7 @@ gh skill install Shu-Wan/sol-skills sol-skill --agent github-copilot --scope use
 gh skill preview Shu-Wan/sol-skills sol-skill
 
 # Pin to a specific release
-gh skill install Shu-Wan/sol-skills sol-skill@v0.2.1 --agent claude-code --scope user
+gh skill install Shu-Wan/sol-skills sol-skill@v0.3.0 --agent claude-code --scope user
 
 # Upgrade later
 gh skill update --all

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -5,10 +5,11 @@ automated verification, and what's a known gap. The eval harness
 requires manual orchestration today, so this document is updated by
 hand before each release.
 
-**Version:** v0.2.1 (see [`../CHANGELOG.md`](../CHANGELOG.md))
-**Last verified:** 2026-04-23 (against v0.2.0 — v0.2.1 is a
-partition-rename release with no behavior changes; tested rows below
-carry over).
+**Version:** v0.3.0 (see [`../CHANGELOG.md`](../CHANGELOG.md))
+**Last verified:** 2026-05-28 (against v0.3.0 — the renewal rows are
+now covered by the runnable L2 `evals/runner/run_l2_renew.py` (8/8) and
+a real end-to-end pass on Sol; other tested rows carry over from
+v0.2.0).
 
 ## Status legend
 
@@ -54,8 +55,9 @@ to the skill should mean adding a row here in the same group.
 | Steers away from `/home` for large data | 🟢 tested | Verified iter-1 |
 | `.solkeep` syntax (gitignore-style, `!` negation, `**` glob) | 🟢 tested | Verified iter-2 eval A: agent produces correct file with explanation |
 | Refuses to bulk-touch `/scratch` (`find -exec touch`) | 🟡 documented | Negative assertion; not yet probed |
-| `sol_renew.py --dry-run` plan correctness | 🟡 documented | L2 mock available; eval pending |
-| `sol_renew.py` actually touches files | 🟡 documented | Manual on Sol; no automated L3 |
+| `sol_renew.py --dry-run` plan correctness | 🟢 tested | L2 `run_l2_renew.py` (v0.3.0): dry-run exits 0 and touches nothing |
+| `sol_renew.py` actually refreshes kept files (recursively) | 🟢 tested | L2 `run_l2_renew.py` (v0.3.0): mtimes refresh across the tree; also run end-to-end on real Sol |
+| `.solkeep` carve-outs honored at run time (`.venv`/`__pycache__` skipped, non-kept dirs skipped) | 🟢 tested | L2 `run_l2_renew.py` (v0.3.0) |
 | File sharing procedure (`chmod` / `install` / `cp` between users) | 🟡 documented | |
 | Scratch-quota-exceeded behavior | 🔴 gap | Would need a fault-injection mock |
 | Concurrent `sol_renew.py` runs | 🔴 gap | No locking; documented behavior is "don't" |

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -109,7 +109,7 @@ to the skill should mean adding a row here in the same group.
 | Multi-port forwarding (stacked `-L`) | 🟡 documented | |
 | OAuth callback reverse tunnel (`-R`) | 🟡 documented | |
 | Tunnel diagnostics (port-in-use, ControlMaster, wrong-side `-L`) | 🟡 documented | |
-| One-command laptop CLI (`solx`) | ⚪ roadmap | Not in v0.2.1; see [`PLAN.md`](PLAN.md) |
+| One-command laptop CLI (`solx`) | ⚪ roadmap | Not yet shipped; see [`PLAN.md`](PLAN.md) |
 | VS Code wrapper (`/usr/local/bin/vscode`) integration | 🔴 gap | Manual smoke only; wrapper itself maintained by ASU |
 
 ### Transferring Data

--- a/skills/sol-skill/SKILL.md
+++ b/skills/sol-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sol-skill
-version: 0.2.1
+version: 0.3.0
 description: Conventions and ready-to-run tooling for ASU's Sol supercomputer. Use whenever a task is happening on Sol — the user mentions Sol or ASU Research Computing, or is clearly on their Sol account (a Sol /scratch path, an sbatch/interactive job, a login/compute node). Covers: renewing /scratch files Sol has flagged for deletion (purge/inactivity warning emails, .solkeep keep-lists, sol_renew.py) and where to store datasets and model caches; writing and managing SLURM jobs (sbatch, GPU and partition/QOS choice, why a job is pending, fairshare); installing software without sudo (module load, uv for Python, tinytex for LaTeX); reaching a Sol compute-node service like Jupyter from a laptop browser; detecting login-vs-compute nodes and choosing where to run heavy I/O (the DTN, a compute node, or a batch job); and transferring data to and from Sol. Not for generic SLURM/HPC on other clusters (Phoenix, NERSC, …), cloud GPUs, or purely local-laptop tasks (local virtualenvs, local LaTeX, local file/timestamp cleanup).
 license: MIT
 ---


### PR DESCRIPTION
Version bump + changelog for the file-level scratch-renewal work that landed in #18 (closes #17).

## Changes
- **`skills/sol-skill/SKILL.md`**: `version: 0.2.1 → 0.3.0`.
- **`CHANGELOG.md`**: promote `[Unreleased]` → `[0.3.0] — 2026-05-28`, add link refs. The entry folds in everything from the renewal cycle: file-level streaming touch pass (bounded memory), `fd`/`rg`/`find` enumeration, the "Where to run it" decision rule, the triggering-optimized `description` + near-miss guard, the `--dry-run`/confirm safety rule, the global `.solkeep` carve-out example, and the runnable L2 eval.
- **`docs/coverage.md`**: bump **Version** → v0.3.0 and **Last verified** → 2026-05-28; flip the renewal rows to 🟢 tested (now covered by `evals/runner/run_l2_renew.py`, 8/8) and add a row for `.solkeep` carve-outs honored at run time.

## Release verification
- **L2:** `evals/runner/run_l2_renew.py` → 8/8 (dry-run safety, recursive refresh, carve-outs respected, non-kept skipped).
- **Real Sol:** the renewal was run end-to-end on Sol during development (the original ~282k-file pass).

## After merge
- I'll create the annotated tag **`v0.3.0`** on the merge commit.
- You handle the GitHub release via your `gh` skill (no `.skill` artifact this round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)