### PR TITLE
fix(solx): completions under Typer's vendored Click; add version/help aliases

### DIFF
--- a/docs/solx.md
+++ b/docs/solx.md
@@ -31,7 +31,8 @@ solx init        # writes ~/.config/solx/config.toml
 | `solx keep` | Renew `/scratch` files Sol flagged for deletion. |
 | `solx config show` / `edit` | Show or edit your config. |
 | `solx completions <bash\|zsh\|fish>` | Print a shell-completion script. |
-| `solx --version` / `--help` | — |
+| `solx version` (alias `--version`) | Print the version. |
+| `solx help` (alias `--help`) | Show help. |
 
 `job` is also spelled `jobs`, `list` is also `ls`, and `solx jump` is short
 for `solx job jump`.

--- a/solx/pyproject.toml
+++ b/solx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solx"
-version = "0.3.0"
+version = "0.3.1"
 description = "CLI for ASU's Sol supercomputer."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/solx/src/solx/__init__.py
+++ b/solx/src/solx/__init__.py
@@ -1,3 +1,3 @@
 """solx — CLI for ASU's Sol supercomputer."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/solx/src/solx/cli.py
+++ b/solx/src/solx/cli.py
@@ -416,16 +416,20 @@ def completions_cmd(
 ) -> None:
     """Print a completion script for `shell`.
 
-    Generated directly from Click's completion machinery rather than
+    Generated directly from Typer's completion machinery rather than
     re-exec'ing the binary, so it works under both the installed `solx` entry
     point and `python -m solx`.
+
+    Uses Typer's own completion classes, which carry the right source templates
+    and env-var wiring (``_SOLX_COMPLETE``, ``_TYPER_COMPLETE_ARGS``) and match
+    Typer's runtime completion handler regardless of how click is packaged.
     """
-    import click.shell_completion as shell_completion
+    from typer._completion_classes import BashComplete, FishComplete, ZshComplete
     from typer.main import get_command
 
-    shell = shell.lower()
-    comp_cls = shell_completion.get_completion_class(shell)
-    if shell not in {"bash", "zsh", "fish"} or comp_cls is None:
+    classes = {"bash": BashComplete, "zsh": ZshComplete, "fish": FishComplete}
+    comp_cls = classes.get(shell.lower())
+    if comp_cls is None:
         typer.echo(f"unknown shell {shell!r}; choose bash, zsh, or fish.", err=True)
         raise typer.Exit(code=2)
     completer = comp_cls(get_command(app), {}, "solx", "_SOLX_COMPLETE")

--- a/solx/src/solx/cli.py
+++ b/solx/src/solx/cli.py
@@ -417,24 +417,27 @@ def completions_cmd(
 ) -> None:
     """Print a completion script for `shell`.
 
-    Generated directly from Typer's completion machinery rather than
-    re-exec'ing the binary, so it works under both the installed `solx` entry
-    point and `python -m solx`.
-
-    Uses Typer's own completion classes, which carry the right source templates
-    and env-var wiring (``_SOLX_COMPLETE``, ``_TYPER_COMPLETE_ARGS``) and match
+    Built with Typer's completion-script generator — the same one behind
+    Typer's ``--show-completion`` — so the emitted script carries the right
+    env-var wiring (``_SOLX_COMPLETE``, ``_TYPER_COMPLETE_ARGS``) and matches
     Typer's runtime completion handler regardless of how click is packaged.
+    No re-exec, so it works under both the installed `solx` entry point and
+    `python -m solx`.
     """
-    from typer._completion_classes import BashComplete, FishComplete, ZshComplete
-    from typer.main import get_command
-
-    classes = {"bash": BashComplete, "zsh": ZshComplete, "fish": FishComplete}
-    comp_cls = classes.get(shell.lower())
-    if comp_cls is None:
+    shell = shell.lower()
+    if shell not in {"bash", "zsh", "fish"}:
         typer.echo(f"unknown shell {shell!r}; choose bash, zsh, or fish.", err=True)
         raise typer.Exit(code=2)
-    completer = comp_cls(get_command(app), {}, "solx", "_SOLX_COMPLETE")
-    typer.echo(completer.source())
+    try:
+        from typer.completion import get_completion_script
+    except ImportError as e:  # Typer internals shifted under an unpinned upgrade
+        typer.echo(f"solx: completion unavailable with this Typer ({e}).", err=True)
+        raise typer.Exit(code=1)
+    typer.echo(
+        get_completion_script(
+            prog_name="solx", complete_var="_SOLX_COMPLETE", shell=shell
+        )
+    )
 
 
 # --- meta: version / help -------------------------------------------------

--- a/solx/src/solx/cli.py
+++ b/solx/src/solx/cli.py
@@ -12,7 +12,8 @@ Surface (see docs/solx.md):
     solx config show [--json]
     solx config edit
     solx completions <bash|zsh|fish>
-    solx --version
+    solx version   (alias of --version)
+    solx help      (alias of --help)
 
 Global output flag: `--json` forces JSON; by default output auto-detects
 (Rich tables on a terminal, JSON when stdout is not a TTY). See `solx.output`.
@@ -434,6 +435,20 @@ def completions_cmd(
         raise typer.Exit(code=2)
     completer = comp_cls(get_command(app), {}, "solx", "_SOLX_COMPLETE")
     typer.echo(completer.source())
+
+
+# --- meta: version / help -------------------------------------------------
+
+
+@app.command("version", help="Show version and exit (alias of --version).")
+def version_cmd() -> None:
+    typer.echo(__version__)
+
+
+@app.command("help", help="Show help and exit (alias of --help).")
+def help_cmd(ctx: typer.Context) -> None:
+    # The root group's help, matching `solx --help`.
+    typer.echo((ctx.parent or ctx).get_help())
 
 
 # --- helpers --------------------------------------------------------------

--- a/solx/tests/test_cli.py
+++ b/solx/tests/test_cli.py
@@ -430,6 +430,15 @@ def test_completions_bash_emits_script(runner: CliRunner) -> None:
     assert "solx" in res.stdout
 
 
+def test_completions_zsh_emits_script(runner: CliRunner) -> None:
+    """zsh emits a valid `#compdef` script wired to Typer's runtime handler."""
+    res = runner.invoke(cli.app, ["completions", "zsh"])
+    assert res.exit_code == 0
+    assert "#compdef solx" in res.stdout
+    assert "_SOLX_COMPLETE=complete_zsh" in res.stdout
+    assert "_TYPER_COMPLETE_ARGS" in res.stdout
+
+
 def test_config_edit_splits_editor_flags(runner: CliRunner, monkeypatch, tmp_path) -> None:
     """$EDITOR with flags (e.g. `code --wait`) is split into argv, not one binary."""
     cfgfile = tmp_path / "config.toml"

--- a/solx/tests/test_cli.py
+++ b/solx/tests/test_cli.py
@@ -46,6 +46,23 @@ def test_help_lists_commands(runner: CliRunner) -> None:
         assert cmd in res.stdout
 
 
+def test_version_subcommand_aliases_flag(runner: CliRunner) -> None:
+    """`solx version` matches `solx --version`."""
+    from solx import __version__
+
+    res = runner.invoke(cli.app, ["version"])
+    assert res.exit_code == 0
+    assert __version__ in res.stdout
+
+
+def test_help_subcommand_aliases_flag(runner: CliRunner) -> None:
+    """`solx help` shows the root help, same as `solx --help`."""
+    res = runner.invoke(cli.app, ["help"])
+    assert res.exit_code == 0
+    for cmd in ("init", "keep", "job", "config", "completions"):
+        assert cmd in res.stdout
+
+
 # ---- alias coverage -----------------------------------------------------
 
 

--- a/solx/uv.lock
+++ b/solx/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "solx"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "pathspec" },


### PR DESCRIPTION
## Problem

`solx completions <shell>` crashed with `ModuleNotFoundError: No module named 'click'`.

Typer now **vendors Click** (as `typer._click`) rather than depending on the third-party package — better for maintenance, compatibility, and future features. The consequence: a freshly installed solx tool venv (Typer 0.26.x) has no top-level `click`. The completions command did `import click.shell_completion`, which resolves in older setups (standalone Click present) but not under a vendoring Typer.

```
$ solx completions zsh
  ❱ import click.shell_completion as shell_completion
ModuleNotFoundError: No module named 'click'
```

## Fix

Generate the script with **`typer.completion.get_completion_script`** — the engine behind Typer's documented `--show-completion`:

- No standalone `click` import (vendored or not) — works regardless of how Typer packages Click; no `click` dependency added, solx keeps relying on Typer.
- Pure template substitution (no click registry, no `get_command`), emitting a script with the right env-var wiring (`_SOLX_COMPLETE`, `_TYPER_COMPLETE_ARGS`) that matches Typer's runtime completion handler.
- Tracks Typer's own supported completion path instead of reconstructing it.
- The Typer import is guarded with `try/except ImportError`: since the dep is `typer>=0.12` (unpinned), a future internals shift fails with a clear stderr message + exit 1 rather than a traceback. (Addresses review feedback re: private Typer internals.)

A repo-wide audit confirmed `completions_cmd` was the only standalone-`click` usage.

## Also in this PR — flag refine (Closes #21)

Add `version` and `help` as command aliases of the existing flags:

- `solx version` → prints the version, same as `solx --version`.
- `solx help` → prints the root group help, byte-identical to `solx --help`.

## Verification

```
$ solx completions zsh
#compdef solx

_solx_completion() {
  eval $(env _TYPER_COMPLETE_ARGS="${words[1,$CURRENT]}" _SOLX_COMPLETE=complete_zsh solx)
}

compdef _solx_completion solx
# exit 0

$ solx completions tcsh   # -> "unknown shell 'tcsh'; ..."  exit 2
$ solx version            # -> 0.3.1   (matches `solx --version`)
$ diff <(solx help) <(solx --help)   # -> identical
```

- Tests: `test_completions_zsh_emits_script`, `test_version_subcommand_aliases_flag`, `test_help_subcommand_aliases_flag`; full suite **177 passed**.
- Bumps solx `0.3.0 → 0.3.1` (`pyproject.toml` + `__init__.py`), `uv.lock` synced; docs surface updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)