### PR TITLE
fix(solx 0.3.2): runtime tab completion + `jump` --overlap

### DIFF
--- a/solx/README.md
+++ b/solx/README.md
@@ -196,7 +196,7 @@ Sol runs Slurm 25.x, which supports `salloc --no-shell` natively.
    allocation N`).
 4. Returns. The allocation continues running in the background as a
    "headless" reservation — nothing is consuming it until you attach.
-5. You attach with `solx job jump`, which exec's `srun --jobid=N --overlap
+5. You attach with `solx job jump`, which execs `srun --jobid=N --overlap
    --pty $default_shell` to drop you onto the compute node.
 
 If the queue stalls, the `start_timeout` config (`--timeout` overrides)

--- a/solx/README.md
+++ b/solx/README.md
@@ -196,8 +196,8 @@ Sol runs Slurm 25.x, which supports `salloc --no-shell` natively.
    allocation N`).
 4. Returns. The allocation continues running in the background as a
    "headless" reservation — nothing is consuming it until you attach.
-5. You attach with `solx job jump`, which exec's `srun --jobid=N --pty
-   $default_shell` to drop you onto the compute node.
+5. You attach with `solx job jump`, which exec's `srun --jobid=N --overlap
+   --pty $default_shell` to drop you onto the compute node.
 
 If the queue stalls, the `start_timeout` config (`--timeout` overrides)
 caps the wait so a stuck request surfaces instead of hanging forever.

--- a/solx/pyproject.toml
+++ b/solx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solx"
-version = "0.3.1"
+version = "0.3.2"
 description = "CLI for ASU's Sol supercomputer."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/solx/src/solx/__init__.py
+++ b/solx/src/solx/__init__.py
@@ -1,3 +1,3 @@
 """solx — CLI for ASU's Sol supercomputer."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/solx/src/solx/cli.py
+++ b/solx/src/solx/cli.py
@@ -49,6 +49,18 @@ app = typer.Typer(
     add_completion=False,
 )
 
+# `add_completion=False` keeps the --install/--show-completion flags off the
+# root command, but it also means Typer never registers its bash/zsh/fish
+# completion classes. Without them, the runtime `_SOLX_COMPLETE=complete_<shell>`
+# dispatch resolves no class and reports "Shell <shell> not supported", so Tab
+# does nothing. Register them at import (before app() runs) so completion fires.
+try:
+    from typer.completion import completion_init
+
+    completion_init()
+except ImportError:  # Typer internals shifted under an unpinned upgrade
+    pass  # completion won't fire, but the rest of the CLI is unaffected
+
 job_app = typer.Typer(
     name="job",
     help="Manage interactive Slurm jobs on Sol.",

--- a/solx/src/solx/jobs.py
+++ b/solx/src/solx/jobs.py
@@ -113,7 +113,7 @@ def cmd_start(
     out.status(f"[green]allocated job[/] [bold]{jobid}[/]")
     out.status(
         f"[dim]attach:[/] solx job jump {jobid}  "
-        f"[dim](or: srun --jobid={jobid} --pty {config.default_shell})[/]"
+        f"[dim](or: srun --jobid={jobid} --overlap --pty {config.default_shell})[/]"
     )
     if out.json_mode:
         out.json({"jobid": jobid, "template": name})

--- a/solx/src/solx/slurm.py
+++ b/solx/src/solx/slurm.py
@@ -246,8 +246,14 @@ def scancel_argv(job_id: str) -> list[str]:
 
 
 def srun_pty_argv(job_id: str, shell: str) -> list[str]:
-    """Argv for attaching a pty shell to a running allocation."""
-    return ["srun", f"--jobid={job_id}", "--pty", shell]
+    """Argv for attaching a pty shell to a running allocation.
+
+    `--overlap` lets the step share the allocation's resources with steps
+    already running in it. Without it, srun demands exclusive use of the node
+    and stalls with "step creation temporarily disabled (Requested nodes are
+    busy)" whenever the job already has a step occupying its resources.
+    """
+    return ["srun", f"--jobid={job_id}", "--overlap", "--pty", shell]
 
 
 def squeue_time_left_argv(job_id: str) -> list[str]:

--- a/solx/tests/test_cli.py
+++ b/solx/tests/test_cli.py
@@ -456,6 +456,25 @@ def test_completions_zsh_emits_script(runner: CliRunner) -> None:
     assert "_TYPER_COMPLETE_ARGS" in res.stdout
 
 
+def test_runtime_completion_dispatch_resolves_shell(monkeypatch, capsys) -> None:
+    """The emitted script calls `_SOLX_COMPLETE=complete_zsh solx` at runtime;
+    that path must resolve the shell (subcommands), not "Shell zsh not
+    supported" — i.e. `completion_init()` ran at import despite
+    add_completion=False.
+    """
+    from typer.completion import shell_complete
+    from typer.main import get_command
+
+    monkeypatch.setenv("_TYPER_COMPLETE_ARGS", "solx ")
+    rc = shell_complete(
+        get_command(cli.app), {}, "solx", "_SOLX_COMPLETE", "complete_zsh"
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "not supported" not in (captured.out + captured.err).lower()
+    assert "init" in captured.out  # top-level subcommands are completed
+
+
 def test_config_edit_splits_editor_flags(runner: CliRunner, monkeypatch, tmp_path) -> None:
     """$EDITOR with flags (e.g. `code --wait`) is split into argv, not one binary."""
     cfgfile = tmp_path / "config.toml"

--- a/solx/tests/test_jobs.py
+++ b/solx/tests/test_jobs.py
@@ -305,7 +305,7 @@ def test_jump_builds_correct_argv() -> None:
         exec_fn=lambda argv: captured.append(argv), out=make_out(),
     )
     assert code == 0
-    assert captured == [["srun", "--jobid=12345", "--pty", "zsh"]]
+    assert captured == [["srun", "--jobid=12345", "--overlap", "--pty", "zsh"]]
 
 
 def test_jump_from_inside_warns_and_proceeds(monkeypatch) -> None:
@@ -319,7 +319,7 @@ def test_jump_from_inside_warns_and_proceeds(monkeypatch) -> None:
         exec_fn=lambda argv: captured.append(argv), out=out,
     )
     assert code == 0
-    assert captured == [["srun", "--jobid=99999", "--pty", "zsh"]]
+    assert captured == [["srun", "--jobid=99999", "--overlap", "--pty", "zsh"]]
     assert "already inside job 99999" in out.stderr.file.getvalue()
 
 
@@ -333,7 +333,7 @@ def test_jump_inside_quiet_suppresses_warning(monkeypatch) -> None:
         exec_fn=lambda argv: captured.append(argv), out=out,
     )
     assert code == 0
-    assert captured == [["srun", "--jobid=99999", "--pty", "zsh"]]
+    assert captured == [["srun", "--jobid=99999", "--overlap", "--pty", "zsh"]]
     assert out.stderr.file.getvalue() == ""
 
 
@@ -347,7 +347,7 @@ def test_jump_most_recent_running() -> None:
     )
     assert code == 0
     # highest jobid (67890) is "most recent"
-    assert captured == [["srun", "--jobid=67890", "--pty", "zsh"]]
+    assert captured == [["srun", "--jobid=67890", "--overlap", "--pty", "zsh"]]
     assert "most recent" in out.stderr.file.getvalue()
 
 

--- a/solx/tests/test_slurm.py
+++ b/solx/tests/test_slurm.py
@@ -193,9 +193,11 @@ def test_scancel_argv() -> None:
 
 
 def test_srun_pty_argv() -> None:
+    # --overlap lets the step share the allocation's busy resources.
     assert slurm.srun_pty_argv("12345", "zsh") == [
         "srun",
         "--jobid=12345",
+        "--overlap",
         "--pty",
         "zsh",
     ]

--- a/solx/uv.lock
+++ b/solx/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "solx"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "pathspec" },


### PR DESCRIPTION
Two independent bug fixes found after #22, batched into 0.3.2.

## Bug 1 — Tab completion never fires at runtime

`solx completions <shell>` emits the right script (fixed in #22), but pressing Tab did nothing. The emitted script calls `_SOLX_COMPLETE=complete_<shell> solx` at runtime; that path printed **"Shell zsh not supported."** and returned nothing.

**Root cause:** `app = typer.Typer(..., add_completion=False)`. Typer only registers its bash/zsh/fish completion classes (via `completion_init()`) when `add_completion=True`. With it off, the runtime dispatch resolves no class → "not supported".

**Fix:** register the classes at import with `typer.completion.completion_init()` (public module), before `app()` runs, while keeping `add_completion=False`. Guarded with `try/except ImportError` so a future Typer internals shift degrades gracefully.

**Why not `add_completion=True`?** That also fixes it, but it adds `--install-completion` / `--show-completion` flags to the root command. The popular convention (uv `generate-shell-completion <shell>`, kubectl/rustup/poetry `completion(s) <shell>`) is an explicit-shell subcommand that prints to stdout — which solx already has as `solx completions <shell>`. Keeping `add_completion=False` stays on that convention instead of bolting on the extra flags.

```
$ env _TYPER_COMPLETE_ARGS="solx " _SOLX_COMPLETE=complete_zsh solx
_arguments '*: :(("init":"Write a starter config.toml." "keep":... "job":...))'   # was: Shell zsh not supported.
```

## Bug 2 — `solx jump` fails to attach to a busy allocation

```
$ solx jump
srun: Job 54101857 step creation temporarily disabled, retrying (Requested nodes are busy)
srun: error: Unable to create step for job 54101857: Job/step already completing or completed
```

**Root cause:** `srun --jobid=N --pty <shell>` demands exclusive node resources, so when the allocation already has a step occupying them the attach stalls and fails.

**Fix:** add `--overlap` so the step shares the allocation's resources — matching the manual workaround (`srun --jobid=N --overlap --pty zsh`).

## Verification

- New `test_runtime_completion_dispatch_resolves_shell`; `srun` argv tests updated (`test_slurm.py`, `test_jobs.py`). Full suite **178 passed**.
- Smoke-checked on Sol: zsh/bash/fish runtime dispatch list subcommands; `solx --version` → 0.3.2.
- Bumps solx `0.3.1 → 0.3.2`; `uv.lock` synced; README attach hint updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)