### PR TITLE
fix(solx 0.3.4): dual-mode zsh completion footer — fpath install works (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ tag for that release.
 - `README.md`: agent-skill install section reduced to the common
   `gh skill install` one-liner (any agentskills.io-spec installer works).
 
+### solx 0.3.4 — zsh completions work installed on fpath (#26)
+
+- `solx completions zsh` now ends with Click's dual-mode footer instead
+  of Typer's bare `compdef`: installed on `fpath`
+  (`solx completions zsh > ~/.zfunc/_solx`), the autoloaded script
+  *calls* the completer, so the first Tab of a session completes instead
+  of returning nothing. The eval/source install keeps working unchanged;
+  if Typer's template ever stops matching, the script is emitted
+  unmodified. bash/fish output untouched.
+- Docs (`solx/README.md`, `docs/solx.md`): both zsh install modes, with
+  the fpath two-liner as the recommended one.
+
 ### solx 0.3.3 — cold-start latency, single-line help aliases, zipapp scripts
 
 - **Cold-start latency on Sol's NFS home** (where every module import is

--- a/docs/solx.md
+++ b/docs/solx.md
@@ -52,6 +52,44 @@ solx job stop              # cancel it when you're done
 
 ---
 
+## Shell completion
+
+`solx completions <shell>` prints a completion script for bash, zsh, or
+fish. For zsh there are two ways to install it, and the emitted script
+supports both:
+
+**Recommended — on `fpath` (one-time, position-independent):**
+
+```zsh
+mkdir -p ~/.zfunc                      # any dir on fpath before compinit
+solx completions zsh > ~/.zfunc/_solx
+```
+
+If `~/.zfunc` isn't on your `fpath` yet, add `fpath=(~/.zfunc $fpath)`
+*before* the `compinit` call in your `.zshrc`. compinit then autoloads
+`_solx` on the first Tab. This is the only mode that works when your
+machine-local config is sourced before compinit runs (common with plugin
+managers like antidote, zinit, or zim).
+
+**Alternative — eval at startup:**
+
+```zsh
+eval "$(solx completions zsh)"         # must run *after* compinit
+```
+
+Same result, but it runs `solx` on every shell startup and fails with
+`command not found: compdef` if placed before compinit.
+
+bash and fish are single-mode; drop the script where the shell's
+completion loader looks:
+
+```shell
+solx completions bash > ~/.local/share/bash-completion/completions/solx
+solx completions fish > ~/.config/fish/completions/solx.fish
+```
+
+---
+
 ## Configuration
 
 `solx` reads one file: `~/.config/solx/config.toml` (or

--- a/solx/README.md
+++ b/solx/README.md
@@ -36,6 +36,29 @@ If `uv` isn't on your `$PATH` yet, install it from
 is older than what `solx` needs (Python ≥ 3.11); `uv tool install`
 provisions its own interpreter, so you don't have to manage one.
 
+### Shell completion
+
+zsh — recommended: install on `fpath`, one-time. Works no matter where
+in your `.zshrc` it lands relative to `compinit`:
+
+```zsh
+mkdir -p ~/.zfunc                      # any dir on fpath before compinit
+solx completions zsh > ~/.zfunc/_solx
+```
+
+(If `~/.zfunc` is new, add `fpath=(~/.zfunc $fpath)` before the
+`compinit` call in your `.zshrc`.) Alternatively, anywhere *after*
+compinit has run you can `eval "$(solx completions zsh)"` — same result,
+but it adds a `solx` exec to every shell startup and dies with
+`command not found: compdef` if eval'd before compinit.
+
+bash and fish:
+
+```shell
+solx completions bash > ~/.local/share/bash-completion/completions/solx
+solx completions fish > ~/.config/fish/completions/solx.fish
+```
+
 ## Quick start
 
 ```shell

--- a/solx/pyproject.toml
+++ b/solx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solx"
-version = "0.3.3"
+version = "0.3.4"
 description = "CLI for ASU's Sol supercomputer."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/solx/src/solx/__init__.py
+++ b/solx/src/solx/__init__.py
@@ -1,3 +1,3 @@
 """solx — CLI for ASU's Sol supercomputer."""
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/solx/src/solx/cli.py
+++ b/solx/src/solx/cli.py
@@ -446,6 +446,35 @@ def config_edit_cmd() -> None:
 
 # --- completions ----------------------------------------------------------
 
+# Click >= 8.x's dual-mode zsh footer. Typer renders its own older zsh
+# template that ends with a bare `compdef`, which only registers the
+# completer — fine when the script is eval'd/sourced after compinit, but
+# installed on fpath (`solx completions zsh > ~/.zfunc/_solx`) compinit
+# autoloads the file body *as* the completer, so the function must also be
+# called or the first Tab of a session produces nothing.
+_ZSH_BARE_COMPDEF = "compdef _solx_completion solx"
+_ZSH_DUAL_MODE_FOOTER = """\
+if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
+    # autoload from fpath, call function directly
+    _solx_completion "$@"
+else
+    # eval/source/. command, register function for later
+    compdef _solx_completion solx
+fi"""
+
+
+def _zsh_dual_mode(script: str) -> str:
+    """Swap the trailing bare ``compdef`` for the dual-mode footer.
+
+    If the script doesn't end with the expected line (a Typer upgrade
+    changed the template), return it unmodified — eval/source installs
+    keep working either way.
+    """
+    head, sep, tail = script.rpartition(_ZSH_BARE_COMPDEF)
+    if not sep or tail.strip():
+        return script
+    return head + _ZSH_DUAL_MODE_FOOTER + tail
+
 
 @app.command(
     "completions",
@@ -465,6 +494,11 @@ def completions_cmd(
     Typer's runtime completion handler regardless of how click is packaged.
     No re-exec, so it works under both the installed `solx` entry point and
     `python -m solx`.
+
+    The zsh script gets a dual-mode footer so both install modes work:
+    eval/source (compdef registers the completer) and fpath/autoload
+    (`solx completions zsh > ~/.zfunc/_solx`, where the autoloaded body
+    must call the completer itself).
     """
     shell = shell.lower()
     if shell not in {"bash", "zsh", "fish"}:
@@ -475,11 +509,12 @@ def completions_cmd(
     except ImportError as e:  # Typer internals shifted under an unpinned upgrade
         typer.echo(f"solx: completion unavailable with this Typer ({e}).", err=True)
         raise typer.Exit(code=1)
-    typer.echo(
-        get_completion_script(
-            prog_name="solx", complete_var="_SOLX_COMPLETE", shell=shell
-        )
+    script = get_completion_script(
+        prog_name="solx", complete_var="_SOLX_COMPLETE", shell=shell
     )
+    if shell == "zsh":
+        script = _zsh_dual_mode(script)
+    typer.echo(script)
 
 
 # --- meta: version / help -------------------------------------------------

--- a/solx/src/solx/config.py
+++ b/solx/src/solx/config.py
@@ -12,7 +12,7 @@ import re
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 # pathspec is imported where the [keep] specs are compiled (not here) so that
 # importing this module stays cheap on NFS; most commands load config without

--- a/solx/src/solx/jobs.py
+++ b/solx/src/solx/jobs.py
@@ -19,7 +19,7 @@ from rich.table import Table
 from solx import slurm
 from solx.config import Config, ConfigError
 from solx.output import Out
-from solx.slurm import Job, Resolution, SlurmError
+from solx.slurm import Job, SlurmError
 
 
 # --- shared rendering -----------------------------------------------------

--- a/solx/tests/test_cli.py
+++ b/solx/tests/test_cli.py
@@ -447,6 +447,7 @@ def test_completions_bash_emits_script(runner: CliRunner) -> None:
     assert res.exit_code == 0
     assert "_SOLX_COMPLETE" in res.stdout  # the env var the script wires up
     assert "solx" in res.stdout
+    assert "loadautofunc" not in res.stdout  # zsh-only post-processing
 
 
 def test_completions_zsh_emits_script(runner: CliRunner) -> None:
@@ -456,6 +457,30 @@ def test_completions_zsh_emits_script(runner: CliRunner) -> None:
     assert "#compdef solx" in res.stdout
     assert "_SOLX_COMPLETE=complete_zsh" in res.stdout
     assert "_TYPER_COMPLETE_ARGS" in res.stdout
+
+
+def test_completions_zsh_dual_mode_footer(runner: CliRunner) -> None:
+    """The zsh script supports both install modes: autoloaded from fpath
+    (the `loadautofunc` branch calls the completer, so the first Tab of a
+    session completes) and eval/source (compdef registers it)."""
+    res = runner.invoke(cli.app, ["completions", "zsh"])
+    assert res.exit_code == 0
+    assert "loadautofunc" in res.stdout
+    assert '_solx_completion "$@"' in res.stdout
+    # the compdef only survives inside the else-branch (indented) — a bare
+    # column-0 compdef would make the script eval-only again
+    assert "compdef _solx_completion solx" not in res.stdout.splitlines()
+    assert res.stdout.rstrip().endswith("fi")
+
+
+def test_zsh_dual_mode_fallback_unmodified() -> None:
+    """A script without the expected trailing compdef (Typer template
+    changed) passes through untouched instead of being mangled."""
+    for script in (
+        "#compdef solx\n_new_typer_footer solx",  # no compdef line at all
+        "compdef _solx_completion solx\nmore lines after",  # not trailing
+    ):
+        assert cli._zsh_dual_mode(script) == script
 
 
 def test_runtime_completion_dispatch_resolves_shell(monkeypatch, capsys) -> None:

--- a/solx/tests/test_cli.py
+++ b/solx/tests/test_cli.py
@@ -8,7 +8,6 @@ so the suite passes off-Sol.
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner

--- a/solx/tests/test_config.py
+++ b/solx/tests/test_config.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
 
 from solx import config as cfg
-from solx.config import Config, ConfigError, JobTemplate
+from solx.config import ConfigError
 from tests.conftest import SAMPLE_CONFIG_TOML
 
 

--- a/solx/tests/test_jobs.py
+++ b/solx/tests/test_jobs.py
@@ -7,7 +7,6 @@ import pytest
 from rich.console import Console
 
 from solx import jobs as jobs_mod
-from solx import slurm
 from solx.config import Config, JobTemplate
 from solx.output import Out
 

--- a/solx/uv.lock
+++ b/solx/uv.lock
@@ -138,7 +138,7 @@ wheels = [
 
 [[package]]
 name = "solx"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "pathspec" },


### PR DESCRIPTION
Closes #26 — the third leg of the completions work (#22 generation, #23 runtime dispatch): **install-mode compatibility** of the emitted zsh script.

## What changed

- **`completions_cmd` post-processes the zsh script** (`solx/src/solx/cli.py`): the trailing bare `compdef _solx_completion solx` from Typer's stock template is replaced with Click ≥ 8.x's dual-mode footer:

  ```zsh
  if [[ $zsh_eval_context[-1] == loadautofunc ]]; then
      # autoload from fpath, call function directly
      _solx_completion "$@"
  else
      # eval/source/. command, register function for later
      compdef _solx_completion solx
  fi
  ```

  Both install modes now work, first Tab included:

  | Install mode | Before | After |
  |---|---|---|
  | `eval "$(solx completions zsh)"` after compinit | ✅ | ✅ |
  | `solx completions zsh > ~/.zfunc/_solx` on `fpath` | ⚠️ first Tab empty | ✅ |

- **Graceful fallback**: if the replace doesn't match (a Typer upgrade changed the template), the script is emitted unmodified — same posture as the `completion_init()` guard from #23. bash/fish output untouched.
- **Tests**: emitted zsh script contains the `loadautofunc` branch, calls `_solx_completion "$@"`, and has no bare column-0 `compdef`; fallback passes unknown scripts through untouched; bash output unaffected. 180 passed.
- **Docs**: `solx/README.md` + `docs/solx.md` document both install modes, with the fpath two-liner as the recommended one.
- **CHANGELOG + patch bump** to 0.3.4 (both `pyproject.toml` and `__init__.py`; `uv.lock` follows).
- **Chore** (second commit): dropped 7 unused imports (ruff F401) that pre-existed on main; `ruff check` is now clean. The ruff *format* divergence is left alone — the repo doesn't configure ruff, so its default style isn't a standard here.

## Verification on Sol

- `zsh -n` parses the emitted script.
- `$zsh_eval_context[-1] == loadautofunc` probe confirms the branch detection on Sol's zsh (autoload → `CALLED-VIA-AUTOLOAD`, source → `SOURCED`).
- End-to-end via `zsh/zpty`: fresh `zsh -f -i` with the script installed **only on fpath**, first Tab on `solx jo` completes to `solx job ` and Enter shows the `job` subgroup help — the exact failure mode from the issue, fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)