### PR TITLE
ci: bump actions/checkout v4 → v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       run:
         working-directory: solx
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv (Python ${{ matrix.python }})
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       # interpreter-specific, so the build and the install shebang agree.
       SOLX_PYTHON: "3.11"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 


### PR DESCRIPTION
Clears the Node 20 deprecation warning on the `ci` and `release` workflows: GitHub forces Node 20 actions to Node 24 by default on **2026-06-16**, and `actions/checkout@v5` runs on Node 24.

One-line bump in each workflow:
- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

No behavior change — `setup-uv@v7` is already Node 24. CI will validate on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)