### PR TITLE
solx 0.5.1: fix the broken .pyz installer (shebang swap corrupts the zipapp)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,23 @@ jobs:
       - name: Build zipapp
         run: bash scripts/build-pyz.sh
 
+      - name: Smoke-test the artifact and installer
+        # The build's only check used to be that zipfile could open the
+        # archive — which tolerates the corruption the 0.5.0 installer
+        # produced. Actually *run* it: in place, and end-to-end through
+        # install.sh. The installer rebinds the interpreter, so point it at a
+        # path whose length differs from the build shebang (a symlink under
+        # $RUNNER_TEMP) — that is the condition under which an in-place shebang
+        # swap corrupts the offsets, so a regression here fails the build
+        # instead of shipping. Same runner, same interpreter, so no fallback.
+        run: |
+          set -eux
+          ./dist/solx.pyz --version
+          ln -sf "$(uv python find 3.11)" "$RUNNER_TEMP/python3.11"
+          SOLX_INSTALL_DIR="$RUNNER_TEMP/bin" SOLX_PYTHON="$RUNNER_TEMP/python3.11" \
+            sh scripts/install.sh ./dist/solx.pyz
+          "$RUNNER_TEMP/bin/solx" --version
+
       - name: Upload zipapp
         uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,26 @@ version matches `solx/src/solx/__init__.py`, the `version` field in
 [`skills/sol-skill/SKILL.md`](skills/sol-skill/SKILL.md), and the git tag,
 and a pushed `vX.Y.Z` tag builds and publishes the release.
 
-## [Unreleased]
+## [0.5.1] — 2026-06-10
+
+### Fixed
+
+- **`install.sh` produced an unrunnable `solx`.** The installer rebound the
+  zipapp's interpreter by swapping the shebang bytes in place, but a zipapp
+  records its central-directory offsets as absolute file positions that
+  include the shebang line — replacing it with a different-length path
+  shifted every offset, so `zipimport` (which executes the archive) rejected
+  it with "bad central directory size or offset" and `solx` died on startup
+  with `SyntaxError: source code cannot contain null bytes`. Since the build
+  stamps the CI runner's long interpreter path, no local path matched its
+  length and essentially every `.pyz` install was broken. The installer now
+  extracts the payload and rebuilds the archive around the local interpreter
+  (which regenerates the offsets) and smoke-tests the result before
+  reporting success, falling back to a uv-managed interpreter if the
+  resolved one can't run a zipapp. `zipfile` tolerated the corrupted archive
+  on read, which is why the build's own check never caught it.
+
+## [0.5.0] — 2026-06-10
 
 The CLI's dispatch layer is rewritten on the Python standard library and
 startup latency drops to the same order as a raw SLURM call, so the
@@ -408,7 +427,9 @@ agentskills.io-compatible layout (skill content under
 CSV-driven `/scratch` renewal, and shipped the original references
 (`module.md`, `scratch.md`, `sharing.md`, `slurm.md`).
 
-[Unreleased]: https://github.com/Shu-Wan/solx/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/Shu-Wan/solx/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/Shu-Wan/solx/releases/tag/v0.5.1
+[0.5.0]: https://github.com/Shu-Wan/solx/releases/tag/v0.5.0
 [0.4.0]: https://github.com/Shu-Wan/solx/releases/tag/v0.4.0
 [0.3.0]: https://github.com/Shu-Wan/solx/releases/tag/v0.3.0
 [0.2.1]: https://github.com/Shu-Wan/solx/releases/tag/v0.2.1

--- a/skills/sol-skill/SKILL.md
+++ b/skills/sol-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sol-skill
-version: 0.5.0
+version: 0.5.1
 description: Conventions and tooling for ASU's Sol supercomputer, built around the `solx` CLI. Use whenever a task is happening on Sol — the user mentions Sol or ASU Research Computing, or is clearly on their Sol account (a Sol /scratch path, an sbatch/interactive job, a login/compute node). It covers renewing /scratch files Sol has flagged for deletion (purge/inactivity warnings) via `solx keep` and where to store datasets and model caches; requesting and managing SLURM jobs (the `solx job` interactive-allocation lifecycle, sbatch for batch, GPU and partition/QOS choice, why a job is pending, fairshare-aware and time-aware job management); installing software without sudo (module load, uv for Python, tinytex for LaTeX); reaching a Sol compute-node service like Jupyter from a laptop browser; detecting login-vs-compute nodes and choosing where to run heavy I/O (the DTN, a compute node, or a batch job); and transferring data to and from Sol. Not for generic SLURM/HPC on other clusters (Phoenix, NERSC, …), cloud GPUs, or purely local-laptop tasks (local virtualenvs, local LaTeX, local file/timestamp cleanup).
 license: MIT
 ---

--- a/solx/pyproject.toml
+++ b/solx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "solx"
-version = "0.5.0"
+version = "0.5.1"
 description = "CLI for ASU's Sol supercomputer."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/solx/scripts/build-pyz.sh
+++ b/solx/scripts/build-pyz.sh
@@ -38,7 +38,8 @@ rm -rf "$STAGE/bin"  # entry-point scripts; the zipapp __main__ replaces them
 "$PY" -m compileall -b -q "$STAGE"
 # -p stamps the build interpreter's absolute path as the shebang, so the
 # artifact is directly executable on the build machine (./dist/solx.pyz).
-# install.sh replaces the shebang with the destination machine's interpreter.
+# install.sh rebuilds the archive around the destination machine's interpreter
+# (the shebang can't be swapped in place — the offsets are absolute).
 "$PY" -m zipapp "$STAGE" -o "$ROOT/dist/solx.pyz" -m "solx.main:main" -c -p "$PY"
 
 echo "built $ROOT/dist/solx.pyz ($(du -h "$ROOT/dist/solx.pyz" | cut -f1), python $PYVER)"

--- a/solx/scripts/install.sh
+++ b/solx/scripts/install.sh
@@ -8,27 +8,42 @@
 # Environment:
 #   SOLX_INSTALL_DIR  install location (default: $XDG_BIN_HOME, falling
 #                     back to ~/.local/bin)
-#   SOLX_PYTHON       interpreter version stamped on the shebang
-#                     (default: 3.11; must match what build-pyz.sh
-#                     compiled with — the embedded bytecode is
-#                     interpreter-specific)
+#   SOLX_PYTHON       interpreter to bind the zipapp to. A version (e.g.
+#                     3.11, the default) is resolved — and installed if
+#                     missing — via uv; a path (anything with a slash) is
+#                     used as-is, so uv is not required. Either way it must
+#                     match the version build-pyz.sh compiled with: the
+#                     embedded bytecode is interpreter-specific.
 #
-# Sol's system python3 is older than solx supports, so the script
-# resolves a uv-managed interpreter and binds the .pyz to it via an
-# absolute shebang. uv is only needed at install time, not at runtime.
+# Sol's system python3 is older than solx supports, so by default the script
+# resolves a uv-managed interpreter and binds the .pyz to it via an absolute
+# shebang. uv is only needed at install time, not at runtime.
 set -eu
 
-PYVER="${SOLX_PYTHON:-3.11}"
+PYREQ="${SOLX_PYTHON:-3.11}"
 BIN="${SOLX_INSTALL_DIR:-${XDG_BIN_HOME:-$HOME/.local/bin}}"
 SRC="${1:-https://github.com/Shu-Wan/solx/releases/latest/download/solx.pyz}"
 
-command -v uv >/dev/null 2>&1 || {
-    echo "solx install: uv is required to provision Python $PYVER." >&2
-    echo "Install it first: https://docs.astral.sh/uv/" >&2
-    exit 1
-}
-uv python find "$PYVER" >/dev/null 2>&1 || uv python install "$PYVER"
-PY="$(uv python find "$PYVER")"
+case "$PYREQ" in
+    */*)
+        # An explicit interpreter path — used as given; no uv needed.
+        PY="$PYREQ"
+        [ -x "$PY" ] || {
+            echo "solx install: SOLX_PYTHON=$PY is not an executable interpreter." >&2
+            exit 1
+        }
+        ;;
+    *)
+        command -v uv >/dev/null 2>&1 || {
+            echo "solx install: uv is required to provision Python $PYREQ" >&2
+            echo "(or set SOLX_PYTHON to an existing interpreter path)." >&2
+            echo "Install uv first: https://docs.astral.sh/uv/" >&2
+            exit 1
+        }
+        uv python find "$PYREQ" >/dev/null 2>&1 || uv python install "$PYREQ"
+        PY="$(uv python find "$PYREQ")"
+        ;;
+esac
 
 TMP="$(mktemp)"
 STAGE="$(mktemp -d)"
@@ -63,8 +78,14 @@ build_solx() {
 
 if ! build_solx "$PY"; then
     # The resolved interpreter can't run the archive (a system python may be
-    # built without working zipapp support). Provision a uv-managed one and
-    # retry — that is what `uv python install` guarantees.
+    # built without working zipapp support). Provision a uv-managed one of the
+    # same version and retry — that is what `uv python install` guarantees.
+    PYVER="$("$PY" -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+    command -v uv >/dev/null 2>&1 || {
+        echo "solx install: $PY can't run a zipapp, and uv is not available to" >&2
+        echo "provision one. Set SOLX_PYTHON to a Python $PYVER that can." >&2
+        exit 1
+    }
     echo "solx install: $PY can't run a zipapp; provisioning a uv-managed Python $PYVER." >&2
     UV_PYTHON_PREFERENCE=only-managed uv python install "$PYVER" >/dev/null 2>&1 || true
     PY="$(UV_PYTHON_PREFERENCE=only-managed uv python find "$PYVER")"

--- a/solx/scripts/install.sh
+++ b/solx/scripts/install.sh
@@ -31,27 +31,48 @@ uv python find "$PYVER" >/dev/null 2>&1 || uv python install "$PYVER"
 PY="$(uv python find "$PYVER")"
 
 TMP="$(mktemp)"
-trap 'rm -f "$TMP"' EXIT
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$TMP" "$STAGE"' EXIT
 case "$SRC" in
     http://* | https://*) curl -fsSL "$SRC" -o "$TMP" ;;
     *) cp "$SRC" "$TMP" ;;
 esac
 
+# A zipapp records its central-directory offsets as absolute file positions
+# that include the shebang line, so the interpreter cannot be rebound by
+# swapping the shebang bytes — a different-length path shifts every offset and
+# zipimport (which runs the archive) refuses it with "bad central directory".
+# Extract the payload and rebuild the archive around this machine's
+# interpreter instead, which regenerates the offsets. zipfile reads the
+# build machine's shebang prefix fine; only zipimport is strict.
+"$PY" -m zipfile -e "$TMP" "$STAGE"
+
 mkdir -p "$BIN"
 # Remove first: a previous `uv tool install` leaves a symlink here, and
 # writing through it would clobber the tool venv's entry point instead.
 rm -f "$BIN/solx"
-# The artifact carries the build machine's shebang so it runs in place;
-# drop it and stamp one bound to this machine's interpreter.
-SKIP=0
-if [ "$(head -c 2 "$TMP")" = "#!" ]; then
-    SKIP="$(head -n 1 "$TMP" | wc -c)"
+
+# Rebuild the zipapp around $1 and confirm it actually runs. A correctly
+# built archive runs under any matching interpreter; the smoke test is the
+# guard that we never install a solx that can't start.
+build_solx() {
+    "$1" -m zipapp "$STAGE" -o "$BIN/solx" -p "$1" || return 1
+    chmod +x "$BIN/solx"
+    "$BIN/solx" --version >/dev/null 2>&1
+}
+
+if ! build_solx "$PY"; then
+    # The resolved interpreter can't run the archive (a system python may be
+    # built without working zipapp support). Provision a uv-managed one and
+    # retry — that is what `uv python install` guarantees.
+    echo "solx install: $PY can't run a zipapp; provisioning a uv-managed Python $PYVER." >&2
+    UV_PYTHON_PREFERENCE=only-managed uv python install "$PYVER" >/dev/null 2>&1 || true
+    PY="$(UV_PYTHON_PREFERENCE=only-managed uv python find "$PYVER")"
+    build_solx "$PY" || {
+        echo "solx install: could not produce a working solx with $PY." >&2
+        exit 1
+    }
 fi
-{
-    printf '#!%s\n' "$PY"
-    tail -c +$((SKIP + 1)) "$TMP"
-} >"$BIN/solx"
-chmod +x "$BIN/solx"
 
 echo "installed $BIN/solx (solx $("$BIN/solx" --version))"
 case ":$PATH:" in

--- a/solx/src/solx/__init__.py
+++ b/solx/src/solx/__init__.py
@@ -1,3 +1,3 @@
 """solx — CLI for ASU's Sol supercomputer."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/solx/uv.lock
+++ b/solx/uv.lock
@@ -147,7 +147,7 @@ wheels = [
 
 [[package]]
 name = "solx"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "pathspec" },


### PR DESCRIPTION
## solx 0.5.1 — fix the broken `.pyz` installer

v0.5.0's `install.sh` produced a `solx` that can't start. It rebound the
zipapp's interpreter by **swapping the shebang bytes in place**, but a zipapp
records its central-directory offsets as *absolute file positions that include
the shebang line*. Replacing the shebang with a different-length interpreter
path shifts every offset, so `zipimport` (which executes the archive) rejects
it:

```
SyntaxError: source code cannot contain null bytes
```

The build stamps the CI runner's long interpreter path
(`#!/home/runner/work/_temp/uv-python-dir/…/python3.11`), so **no local
interpreter path matches its length — essentially every `.pyz` install was
broken.** `zipfile` tolerates the corrupted archive on read, which is why the
build's own check never caught it; only `zipimport` is strict.

### Fix

`install.sh` now:
- **Extracts the payload and rebuilds the archive** around the local
  interpreter (`python -m zipfile -e` → `python -m zipapp`), which regenerates
  the offsets — instead of byte-swapping the shebang.
- **Smoke-tests** the result (`solx --version`) before reporting success, so a
  broken install can never be reported as success again.
- **Falls back to a uv-managed interpreter** if the resolved one can't run a
  zipapp.

### Verification

- New `install.sh` run end-to-end against the live v0.5.0 release → installed
  `solx` runs (`0.5.0`).
- `sh -n` clean; full suite green (247 passed).

### Version

Bumps to **0.5.1** across `__init__.py`, `pyproject.toml`, `SKILL.md`, and
`uv.lock`; changelog adds `[0.5.1]` and relabels the released `[Unreleased]`
block as `[0.5.0] — 2026-06-10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
