### PR TITLE
solx 1.1.0: agent command taxonomy + proactive PENDING playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ version matches the `version` field in [`solx/Cargo.toml`](solx/Cargo.toml)
 and in [`skills/sol-skill/SKILL.md`](skills/sol-skill/SKILL.md), and the git
 tag, and a pushed `vX.Y.Z` tag builds and publishes the release.
 
-## [Unreleased]
+## [1.1.0] — 2026-06-15
 
 Skill guidance for AI agents — framing/packaging changes, no new
 commands (issue #36).

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -5,7 +5,7 @@ automated verification, and what's a known gap. The eval harness
 requires manual orchestration today, so this document is updated by
 hand before each release.
 
-**Version:** v1.0.0 (see [`../CHANGELOG.md`](../CHANGELOG.md))
+**Version:** v1.1.0 (see [`../CHANGELOG.md`](../CHANGELOG.md))
 **Last verified:** the `solx` CLI is covered by its own crate suite
 (`cargo test` in `solx/`: unit tests per module plus the end-to-end
 `tests/cli.rs`, including a real-touch renewal test), which runs in CI.

--- a/skills/sol-skill/SKILL.md
+++ b/skills/sol-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sol-skill
-version: 1.0.0
+version: 1.1.0
 description: Conventions and tooling for ASU's Sol supercomputer, built around the `solx` CLI. Use whenever a task is happening on Sol — the user mentions Sol or ASU Research Computing, or is clearly on their Sol account (a Sol /scratch path, an sbatch/interactive job, a login/compute node). It covers renewing /scratch files Sol has flagged for deletion (purge/inactivity warnings) via `solx keep` and where to store datasets and model caches; requesting and managing SLURM jobs (the `solx job` interactive-allocation lifecycle, sbatch for batch, GPU and partition/QOS choice, why a job is pending, fairshare-aware and time-aware job management); installing software without sudo (module load, uv for Python, tinytex for LaTeX); reaching a Sol compute-node service like Jupyter from a laptop browser; detecting login-vs-compute nodes and choosing where to run heavy I/O (the DTN, a compute node, or a batch job); and transferring data to and from Sol. Not for generic SLURM/HPC on other clusters (Phoenix, NERSC, …), cloud GPUs, or purely local-laptop tasks (local virtualenvs, local LaTeX, local file/timestamp cleanup).
 license: MIT
 ---

--- a/solx/Cargo.lock
+++ b/solx/Cargo.lock
@@ -594,7 +594,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "solx"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/solx/Cargo.toml
+++ b/solx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solx"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "CLI for ASU's Sol supercomputer."
 license = "MIT"


### PR DESCRIPTION
Release commit for the issue #36 skill changes (content merged in #37).

## What's in 1.1.0
- Agent-vs-human command taxonomy for status queries (parseable SLURM/`--json` default; `show*` wrappers only to show a human).
- Proactive "job is PENDING" decision-tree playbook in the SKILL body (diagnose Reason+ETA → classify → right-size → reroute in place with `scontrol update job`, don't spray partitions).
- Commands verified against the live Sol scheduler; hardened by an adversarial review (corrected `%G`-vs-`GresUsed`, multi-word `Reason` truncation, reason strings).

## Release mechanics (per DEVELOPMENT.md)
- Bumped the **one version line**: `solx/Cargo.toml`, `skills/sol-skill/SKILL.md` (`version:`), and `solx/Cargo.lock` — all now `1.1.0`, so the release workflow's tag/version check passes.
- Moved CHANGELOG `[Unreleased]` → `## [1.1.0] — 2026-06-15`.
- Refreshed `docs/coverage.md` version line.
- No CLI source change — the binary differs only in the embedded cheat sheet (`include_str!` of `references/cheatsheet.md`). `cargo test --locked` passes (143 tests).

## After merge
Tag `v1.1.0` on the merge commit and push it → `.github/workflows/release.yml` builds the static musl binary and publishes the GitHub Release. Installation/upgrade is then the usual `curl … releases/latest/download/solx-x86_64-unknown-linux-musl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)