### PR TITLE
docs: fix stale v1.0.0 references after the 1.0.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing tag to (re)build a release for, e.g. v1.0.0"
+        description: "Existing tag to (re)build a release for, e.g. v1.2.3"
         required: true
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -541,7 +541,8 @@ agentskills.io-compatible layout (skill content under
 CSV-driven `/scratch` renewal, and shipped the original references
 (`module.md`, `scratch.md`, `sharing.md`, `slurm.md`).
 
-[Unreleased]: https://github.com/Shu-Wan/solx/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/Shu-Wan/solx/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/Shu-Wan/solx/releases/tag/v1.0.1
 [1.0.0]: https://github.com/Shu-Wan/solx/releases/tag/v1.0.0
 [0.5.1]: https://github.com/Shu-Wan/solx/releases/tag/v0.5.1
 [0.5.0]: https://github.com/Shu-Wan/solx/releases/tag/v0.5.0

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -271,8 +271,13 @@ publish the GitHub Release with it attached). Before tagging:
    (`cd solx && cargo test`).
 3. Walk the L3 manual checklist on real Sol (login + compute node).
 4. Hand-edit `docs/coverage.md`: bump the "Last verified" date, flip
-   any cells in the matrix, refresh "Known gaps". Move the
-   `[Unreleased]` notes under a `## [X.Y.Z]` heading in `CHANGELOG.md`.
+   any cells in the matrix, refresh "Known gaps", and bump its
+   `**Version:**` line. Move the `[Unreleased]` notes under a
+   `## [X.Y.Z]` heading in `CHANGELOG.md`, **and update the
+   link-reference footer at the bottom** (repoint `[Unreleased]` to
+   `compare/vX.Y.Z...HEAD` and add a `[X.Y.Z]` release-tag target) — a
+   missed footer leaves the new heading as a dead link. The README's
+   version is shown by the dynamic Release badge, so it needs no edit.
 5. If the release added a user-visible capability, touch the "What this
    skill helps with" bullets in `skills/sol-skill/SKILL.md`.
 6. Commit the docs on the release commit, then tag `vX.Y.Z` and push —

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ same way.
 
 ## Development
 
-- **Changelog** — [CHANGELOG.md](CHANGELOG.md); current release **v1.0.0**
-  (native Rust binary).
+- **Changelog** — [CHANGELOG.md](CHANGELOG.md); the current release is
+  shown by the **Release** badge at the top of this README.
 - **Roadmap** — [docs/ROADMAP.md](docs/ROADMAP.md).
 - **Contributing, tests, and the eval harness** —
   [DEVELOPMENT.md](DEVELOPMENT.md) and


### PR DESCRIPTION
Post-release cleanup of v1.0.0 references the 1.0.1 release (#39) didn't touch. Docs-only — the published v1.0.1 tag/release is unaffected.

## Fixes
- **README** — the "current release **v1.0.0**" bullet was hardcoded. De-hardcoded to point at the dynamic **Release** badge, so it can't go stale again.
- **CHANGELOG footer** — the link-reference definitions still had `[Unreleased]: …compare/v1.0.0…HEAD` and **no `[1.0.1]` target**, which left the `## [1.0.1]` heading as a dead link. Repointed `[Unreleased]` to `v1.0.1…HEAD` and added `[1.0.1]: …/releases/tag/v1.0.1`.
- **release.yml** — the `workflow_dispatch` example tag is now generic (`v1.2.3`) instead of `v1.0.0`.
- **DEVELOPMENT.md** — added the two release-checklist steps that were missed this round (update the CHANGELOG link-reference footer; bump `coverage.md`'s `**Version:**` line) and noted the README version is now dynamic.

## Why these were missed
The release checklist (step 4) covered moving the `[Unreleased]` *heading* but not the *footer link definitions* or the README/coverage version lines — so they drifted. The DEVELOPMENT.md change closes that gap for next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)